### PR TITLE
Windows VST3 plugin hosting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,11 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        # No submodules: external/vst3sdk is the only one and VST3 hosting is
-        # off by default (a licensing opt-in, see CMakeLists.txt).
+        with:
+          # external/vst3sdk is the only submodule. INFINITE_ENABLE_VST3
+          # defaults ON (see CMakeLists.txt), so the SDK headers must always
+          # be present for the configure step below to succeed.
+          submodules: recursive
 
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
@@ -86,6 +89,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Configure
         run: cmake -S . -B build -G "Visual Studio 17 2022" -A ${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,18 +138,21 @@ jobs:
       - name: Assert no Visual C++ redistributable dependency
         shell: pwsh
         run: |
-          $bytes = [System.IO.File]::ReadAllBytes("build/Release/Infinite.exe")
-          $ascii = [System.Text.Encoding]::ASCII.GetString($bytes)
-          $bad = @("MSVCP140", "VCRUNTIME140", "MSVCP140D", "VCRUNTIME140D") |
-                 Where-Object { $ascii -match $_ }
-          if ($bad) {
-            Write-Error ("Infinite.exe imports the VC++ redistributable CRT (" +
-                         ($bad -join ", ") +
-                         "). It will fail to launch on a clean Windows install. " +
-                         "CMAKE_MSVC_RUNTIME_LIBRARY should be MultiThreaded - see CMakeLists.txt.")
-            exit 1
+          $exes = @("build/Release/Infinite.exe", "build/Release/infinite-vst3-scanner.exe")
+          foreach ($exe in $exes) {
+            $bytes = [System.IO.File]::ReadAllBytes($exe)
+            $ascii = [System.Text.Encoding]::ASCII.GetString($bytes)
+            $bad = @("MSVCP140", "VCRUNTIME140", "MSVCP140D", "VCRUNTIME140D") |
+                   Where-Object { $ascii -match $_ }
+            if ($bad) {
+              Write-Error ("$exe imports the VC++ redistributable CRT (" +
+                           ($bad -join ", ") +
+                           "). It will fail to launch on a clean Windows install. " +
+                           "CMAKE_MSVC_RUNTIME_LIBRARY should be MultiThreaded - see CMakeLists.txt.")
+              exit 1
+            }
+            Write-Host "OK: $exe is statically linked, no vc_redist dependency."
           }
-          Write-Host "OK: statically linked CRT, no vc_redist dependency."
 
       # package.ps1 is the local developer path (it drives its own configure
       # and hardcodes x64); here the build already exists, so just stage it.
@@ -158,6 +161,7 @@ jobs:
         run: |
           mkdir -p dist/Infinite
           cp build/Release/Infinite.exe dist/Infinite/
+          cp build/Release/infinite-vst3-scanner.exe dist/Infinite/
           cp README.md LICENSE dist/Infinite/ 2>/dev/null || true
 
       - name: Upload

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,13 +399,11 @@ if(WIN32)
     set_target_properties(Infinite PROPERTIES WIN32_EXECUTABLE TRUE)
 
     if(INFINITE_ENABLE_VST3)
-        # Foundation-phase Windows VST3 hosting: the portable SDK-hosting
-        # logic (src/platform/win/PluginVST3Win.cpp) compiles and links, but
-        # unlike the macOS side there is no out-of-process scanner yet -
-        # enumeration stays routed through PluginHostWin.cpp's existing
-        # no-op stub. That's a known, temporary gap (see the Windows VST3
-        # hosting plan), not a silent regression: no codesign step is needed
-        # here either, since Windows has no equivalent requirement.
+        # Windows VST3 hosting: the portable SDK-hosting logic
+        # (src/platform/win/PluginVST3Win.cpp) also hosts out-of-process
+        # scanning + crash-safety (sentinel/blocklist under %APPDATA%\Infinite),
+        # mirroring macOS. No codesign step is needed here, since Windows has
+        # no equivalent requirement.
         target_compile_definitions(Infinite PRIVATE INFINITE_ENABLE_VST3=1)
         target_include_directories(Infinite PRIVATE
             ${VST3_SDK_DIR}
@@ -418,6 +416,51 @@ if(WIN32)
             ${VST3_SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
             ${VST3_SDK_DIR}/public.sdk/source/common/commoniids.cpp
         )
+
+        # Out-of-process scanner helper, mirroring the macOS
+        # infinite-vst3-scanner target below: a disposable console-subsystem
+        # process that loads one plugin bundle at a time so a crashing or
+        # hanging plugin only costs a dead child, never the app itself.
+        add_executable(infinite-vst3-scanner
+            src/scanner_main_win.cpp
+            src/platform/win/PluginVST3Win.cpp
+            src/platform/win/PlatformWin.cpp
+            ${NODE_EDITOR_DIR}/crude_json.cpp
+            ${VST3_SDK_DIR}/pluginterfaces/base/coreiids.cpp
+            ${VST3_SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
+            ${VST3_SDK_DIR}/public.sdk/source/common/commoniids.cpp
+        )
+        target_include_directories(infinite-vst3-scanner PRIVATE
+            src src/core src/nodes src/platform src/audio
+            ${IMGUI_DIR} ${IMGUI_DIR}/backends ${IMGUI_DIR}/misc/cpp
+            ${NODE_EDITOR_DIR}
+            ${STB_DIR}
+            external/json
+            external/shine
+            ${VST3_SDK_DIR}
+            ${VST3_SDK_DIR}/pluginterfaces
+            ${VST3_SDK_DIR}/public.sdk
+        )
+        target_compile_definitions(infinite-vst3-scanner PRIVATE
+            INFINITE_ENABLE_VST3=1
+            NOMINMAX
+            WIN32_LEAN_AND_MEAN
+            _CRT_SECURE_NO_WARNINGS
+            INFINITE_VST3_SCANNER=1
+        )
+        # Console subsystem, not WIN32_EXECUTABLE: this process only ever
+        # talks to its parent over a stdout pipe (see RunProbeChild in
+        # PluginVST3Win.cpp), so it needs plain main()/console CRT startup,
+        # not the GUI subsystem Infinite.exe uses.
+        target_link_libraries(infinite-vst3-scanner PRIVATE
+            ole32 shell32 gdi32 user32 advapi32
+        )
+        add_dependencies(Infinite infinite-vst3-scanner)
+        add_custom_command(TARGET Infinite POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                    "$<TARGET_FILE:infinite-vst3-scanner>"
+                    "$<TARGET_FILE_DIR:Infinite>/infinite-vst3-scanner.exe"
+            COMMENT "Copying scanner helper next to Infinite.exe")
     endif()
     target_link_options(Infinite PRIVATE /ENTRY:mainCRTStartup)
 elseif(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,9 +102,9 @@ set(NODE_EDITOR_DIR external/imgui-node-editor)
 set(STB_DIR external/stb)
 set(SYPHON_DIR external/syphon)
 
-if(INFINITE_ENABLE_VST3 AND NOT APPLE)
-    message(FATAL_ERROR "INFINITE_ENABLE_VST3 is only wired up on macOS right now; "
-                        "the Windows platform layer reports plugin hosting as unavailable.")
+if(INFINITE_ENABLE_VST3 AND NOT APPLE AND NOT WIN32)
+    message(FATAL_ERROR "INFINITE_ENABLE_VST3 is only wired up on macOS and Windows right now; "
+                        "this platform's layer reports plugin hosting as unavailable.")
 endif()
 
 if(INFINITE_ENABLE_VST3)
@@ -397,6 +397,28 @@ if(WIN32)
     # GUI-subsystem executable that still uses plain main(): MSVC's default
     # WinMain entry doesn't exist here, mainCRTStartup forwards to main().
     set_target_properties(Infinite PROPERTIES WIN32_EXECUTABLE TRUE)
+
+    if(INFINITE_ENABLE_VST3)
+        # Foundation-phase Windows VST3 hosting: the portable SDK-hosting
+        # logic (src/platform/win/PluginVST3Win.cpp) compiles and links, but
+        # unlike the macOS side there is no out-of-process scanner yet -
+        # enumeration stays routed through PluginHostWin.cpp's existing
+        # no-op stub. That's a known, temporary gap (see the Windows VST3
+        # hosting plan), not a silent regression: no codesign step is needed
+        # here either, since Windows has no equivalent requirement.
+        target_compile_definitions(Infinite PRIVATE INFINITE_ENABLE_VST3=1)
+        target_include_directories(Infinite PRIVATE
+            ${VST3_SDK_DIR}
+            ${VST3_SDK_DIR}/pluginterfaces
+            ${VST3_SDK_DIR}/public.sdk
+        )
+        target_sources(Infinite PRIVATE
+            src/platform/win/PluginVST3Win.cpp
+            ${VST3_SDK_DIR}/pluginterfaces/base/coreiids.cpp
+            ${VST3_SDK_DIR}/public.sdk/source/vst/vstinitiids.cpp
+            ${VST3_SDK_DIR}/public.sdk/source/common/commoniids.cpp
+        )
+    endif()
     target_link_options(Infinite PRIVATE /ENTRY:mainCRTStartup)
 elseif(APPLE)
     target_include_directories(Infinite PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 # is GPLv3-or-proprietary, and linking it makes the distributed binary GPLv3
 # too (see LICENSE). Do not flip this default without the user's explicit
 # sign-off - it's a licensing decision, not a technical one.
-option(INFINITE_ENABLE_VST3 "Build the GPLv3 VST3 plugin backend" OFF)
+option(INFINITE_ENABLE_VST3 "Build the GPLv3 VST3 plugin backend" ON)
 
 set(IMGUI_DIR external/imgui)
 set(NODE_EDITOR_DIR external/imgui-node-editor)

--- a/LICENSE
+++ b/LICENSE
@@ -24,7 +24,8 @@ SOFTWARE.
 
 Infinite's own source code is licensed under the MIT License above.
 
-Optionally building with `INFINITE_ENABLE_VST3=ON` links the Steinberg VST3 SDK,
-which is licensed under the GNU General Public License version 3 (GPLv3). When
-distributed with VST3 support enabled, the combined binary must be distributed
-under the terms of the GPLv3.
+By default, the build links the Steinberg VST3 SDK (`INFINITE_ENABLE_VST3=ON`),
+which is licensed under the GNU General Public License version 3 (GPLv3). The
+distributed binary of a default build must therefore be distributed under the
+terms of the GPLv3. Building with `-DINFINITE_ENABLE_VST3=OFF` excludes the VST3
+SDK and the resulting binary remains under the plain MIT terms above.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Architecturally it is a descendant of [BespokeSynth](https://github.com/BespokeS
 - **Native Third-Party Hosting**: Drag AU plugins directly onto the canvas or select from the auto-indexed **Plugins** library.
 - **Floating Native Editor Windows**: Plugins open in their native graphical interface.
 - **Parameter Mapping & Modulation**: Enable **configure**, touch any control in the plugin window, and it exposes an automated slider with its own modulation pin on the node canvas.
-- **VST3 is opt-in and off by default.** AU hosting ships unconditionally. VST3 hosting requires building with `-DINFINITE_ENABLE_VST3=ON` and the `external/vst3sdk` submodule (`git submodule update --init --recursive external/vst3sdk`), because the Steinberg VST3 SDK is GPLv3-or-commercial and Infinite's own source is MIT — enabling VST3 makes the *distributed binary* GPLv3 (see `LICENSE`). A default build has no VST3 support and the Plugins panel says so.
+- **VST3 ships by default**, alongside unconditional AU hosting. It requires the `external/vst3sdk` submodule (`git submodule update --init --recursive external/vst3sdk`); because the Steinberg VST3 SDK is GPLv3-or-commercial and Infinite's own source is MIT, a default build's *distributed binary* is GPLv3 (see `LICENSE`). Build with `-DINFINITE_ENABLE_VST3=OFF` to drop VST3 and keep the binary under plain MIT — that build has no VST3 support and the Plugins panel says so.
 
 ### 5. Procedural 3D Geometry & Simulation
 - **Unified Geometry Pipeline**: Modernized geometry pipeline supporting meshes, point clouds, and 3D spline curves over unified cables.
@@ -203,11 +203,12 @@ src/
 
 ## License
 
-Infinite is open-source software licensed under the **MIT License** — see [LICENSE](LICENSE).
+Infinite's own source is licensed under the **MIT License** — see [LICENSE](LICENSE). Because VST3 hosting is included by default and links the GPLv3-licensed Steinberg VST3 SDK, the distributed binary of a default build is GPLv3; build with `-DINFINITE_ENABLE_VST3=OFF` for a plain-MIT binary.
 
 **Vendored & Third-Party Dependencies:**
 - [Dear ImGui](https://github.com/ocornut/imgui) (MIT)
 - [imgui-node-editor](https://github.com/thedmd/imgui-node-editor) (MIT)
 - [stb](https://github.com/nothings/stb) (Public Domain)
 - [GLFW](https://github.com/glfw/glfw) (zlib)
+- [Steinberg VST3 SDK](https://github.com/steinbergmedia/vst3sdk) (GPLv3, or proprietary Steinberg license)
 

--- a/docs/windows-vst3-status.md
+++ b/docs/windows-vst3-status.md
@@ -24,11 +24,16 @@ style. SEH guarding extended to `createView`/`getSize`/`setFrame`/`attached`/
 `PluginOpenEditor`/`CloseEditor`/`EditorIsOpen`/`AnyPluginEditorOpen`/
 `PumpPluginEditorEvents` dispatch.
 
-**Phase 3 — Out-of-process scanning + loader hardening. Implemented this
-session; compiles and links on macOS (regression build), pushed for Windows
-x64 + ARM64 CI — not yet runtime-verified on Windows.**
-All eleven gaps below are addressed in code. See "What CI proves vs. what
-doesn't" at the bottom before relying on any of this at runtime.
+**Phase 3 — Out-of-process scanning + loader hardening. Done, CI-confirmed
+compiling/linking (Windows x64 + ARM64) — not yet runtime-verified on
+Windows.**
+All eleven gaps below are addressed in code. Landed in two pushes: the
+initial implementation, then a fix-up commit for two build errors CI caught
+(a forward-reference to `LoadVST3Module`/`UnloadVST3Module` that only the
+scanner target's unbatched per-TU compile surfaced, and a `LoadCursorW`
+ANSI/wide mismatch from `IDC_ARROW` under a non-`UNICODE` build). See "What
+CI proves vs. what doesn't" at the bottom before relying on any of this at
+runtime.
 
 No local MSVC in this environment — verification is compile-only via GitHub
 Actions CI (`.github/workflows/build.yml`, Windows x64 + ARM64 jobs). Never

--- a/docs/windows-vst3-status.md
+++ b/docs/windows-vst3-status.md
@@ -1,0 +1,156 @@
+# Windows VST3 Hosting — Status
+
+Branch: `feature/windows-vst3-hosting` (identical tree to `bugfix/param-bound-honesty`;
+the latter is a misnamed duplicate of the same tip — use the feature branch).
+
+## Where it stands
+
+**Phase 1 — Foundation. Done, CI-confirmed compiling/linking (Windows x64 + ARM64).**
+`src/platform/win/PluginVST3Win.cpp` hosts the SDK's
+`IComponent`/`IEditController`/`IAudioProcessor` directly: host glue classes,
+create/init/process/parameter/state logic, DLL loading, UTF-16 handling.
+`INFINITE_ENABLE_VST3` defaults `ON` (`CMakeLists.txt`; GPLv3 licensing
+consequence accepted, see `LICENSE`). SEH crash guarding
+(`RunPluginCallGuarded`) covers state save/restore.
+
+**Phase 2 — Editor window (HWND) hosting. Done, CI-confirmed compiling/linking.**
+Real top-level Win32 window embedding the plugin's `IPlugView` via
+`kPlatformTypeHWND`. `HostPlugFrame` implements `IPlugFrame::resizeView`.
+Soft-close semantics (`WM_CLOSE` hides rather than destroys, matching Mac's
+`windowWillClose:`). `canResize()` respected for fixed vs. resizable window
+style. SEH guarding extended to `createView`/`getSize`/`setFrame`/`attached`/
+`onSize`, tracked by an `editorUnstable` flag independent from
+`stateCallsUnstable`. Wired into `PluginHostWin.cpp`'s
+`PluginOpenEditor`/`CloseEditor`/`EditorIsOpen`/`AnyPluginEditorOpen`/
+`PumpPluginEditorEvents` dispatch.
+
+**Phase 3 — Out-of-process scanning + loader hardening. Implemented this
+session; compiles and links on macOS (regression build), pushed for Windows
+x64 + ARM64 CI — not yet runtime-verified on Windows.**
+All eleven gaps below are addressed in code. See "What CI proves vs. what
+doesn't" at the bottom before relying on any of this at runtime.
+
+No local MSVC in this environment — verification is compile-only via GitHub
+Actions CI (`.github/workflows/build.yml`, Windows x64 + ARM64 jobs). Never
+claim runtime behavior (a window appearing, a plugin loading, a scan finding
+something) beyond what CI proves.
+
+## The eleven gaps — final status
+
+1. **ARM64 wrong bundle subfolder — fixed.** `LoadVST3Module` in
+   `PluginVST3Win.cpp` now selects `arm64-win` / `arm64ec-win` / `x86_64-win`
+   at compile time from the build target (`_M_ARM64EC`/`_M_ARM64`), with a
+   fallback that scans the expected arch folder for any `.vst3` DLL, then
+   falls back further to scanning every `Contents\*-win\` folder.
+
+2. **Single-file `.vst3` DLLs — fixed.** `EnumerateVST3Plugins`'s folder walk
+   now collects both a directory named `*.vst3` (not recursed into further)
+   and a plain file named `*.vst3`.
+
+3. **No altered DLL search path — fixed.** `LoadVST3Module` now calls
+   `LoadLibraryExW(..., LOAD_WITH_ALTERED_SEARCH_PATH)` with an absolute path
+   (required by that flag), so a plugin's sibling DLLs resolve.
+
+4. **No OLE init on the editor/UI thread — fixed, with one deliberate
+   deviation.** `EnsureOleInitializedOnThisThreadOnce()` calls
+   `OleInitialize` once per thread, called from `PluginVST3OpenEditor`. There
+   is **no matching `OleUninitialize`** — this codebase has no app-lifetime
+   shutdown hook anywhere in the Windows platform layer to pair one with
+   (verified by grepping `src/platform/win/*` for existing shutdown pairs;
+   only Media Foundation's own `MFShutdown` calls exist, unrelated). OLE is
+   left initialized for the process lifetime and released by the OS at exit,
+   matching the same pattern already used for this file's
+   `RegisterEditorWindowClassOnce()`. This is a judgment call, not an
+   oversight — flagging it explicitly since the original plan asked for a
+   matching `OleUninitialize`.
+
+5. **Text-mode stdout would corrupt the scan wire format — fixed.**
+   `src/scanner_main_win.cpp` (new file, the Windows counterpart to
+   `src/scanner_main.mm`) calls `_setmode(_fileno(stdout), _O_BINARY)` before
+   printing. `main.cpp`'s `--vst3-scan-bundle` fallback child mode gets the
+   same fix. `ParseProbeOutput` in `PluginVST3Win.cpp` also strips a trailing
+   `\r` defensively.
+
+6. **`infinite-vst3-scanner.exe` needed console subsystem — fixed.** The new
+   CMake target has no `WIN32_EXECUTABLE` property, so it links as a console
+   binary via plain `main()`.
+
+7. **No Windows scanner target — fixed.** `CMakeLists.txt`'s `if(WIN32)`
+   branch now has an `add_executable(infinite-vst3-scanner ...)` target
+   (sources: `scanner_main_win.cpp`, `PluginVST3Win.cpp`, `PlatformWin.cpp`,
+   `crude_json.cpp`, VST3 SDK iid sources), a post-build copy next to
+   `Infinite.exe`, and `.github/workflows/build.yml` stages and CRT-checks it
+   alongside `Infinite.exe` in the uploaded artifact. `package.ps1` (the local
+   dev packaging script) copies it too.
+
+8. **Stale comment: flag default — fixed.** `PluginHostWin.cpp`'s header
+   comment now describes the real dispatch (out-of-process scanning,
+   sentinel/blocklist) instead of the old "flag off is the default" claim.
+
+9. **Stale comment: rescan gap — fixed**, alongside gap 11's real
+   implementation (comment and code replaced together).
+
+10. **Blocklist/search-folder accessors were unconditional stubs — fixed.**
+    `EnumerateVST3Plugins`, `DescribeVST3Bundle`, `CacheVST3BundlePath`,
+    `SetVST3SearchFolders`, `VST3Blocklist`, `ClearVST3Blocklist`, and
+    `VST3ScanFailures` are now defined directly in the `Platform` namespace
+    by `PluginVST3Win.cpp` when `INFINITE_ENABLE_VST3` is on;
+    `PluginHostWin.cpp` keeps its stub definitions guarded behind
+    `#if !INFINITE_ENABLE_VST3` so the two never collide at link time.
+
+11. **No blocklist/sentinel persistence — fixed.** Ported from
+    `PluginVST3.mm`'s `LoadBlocklistLocked`/`SaveBlocklistLocked`/
+    `CheckSentinelForCrashLocked`/`EnsureSentinelCheckedOnce`/
+    `IsBlocklistedPath`/`WriteSentinel`/`ClearSentinel`/`RecordScanFailure`/
+    `AddToBlocklistLocked`, storing `PluginScanSentinel.txt` and
+    `PluginVST3Blocklist.json` under `%APPDATA%\Infinite` (`crude_json` for
+    the blocklist, `std::call_once` in place of `dispatch_once`, `_commit`
+    in place of `fsync` for the durable sentinel write). The step-3 targeted
+    rescan in `PluginVST3Win.cpp`'s resolve path is restored, mirroring
+    `PluginVST3.mm` but with Windows default folders
+    (`%COMMONPROGRAMFILES%\VST3`, `%LOCALAPPDATA%\Programs\Common\VST3`) plus
+    `GetExtraVST3SearchFolders()`.
+
+`ProbeVST3BundleOutOfProcess`/`ProbeVST3BundlesBatch` are also implemented
+(`CreatePipe`+`CreateProcessW`+`STARTF_USESTDHANDLES`, stderr to `NUL`,
+non-blocking drain via `PeekNamedPipe`, 10s single/60s batch deadlines,
+`TerminateProcess` on timeout, `GetExitCodeProcess` mapped onto
+`ProbeOutcome`), with the read handle marked non-inherited and the write
+handle closed in the parent after spawn.
+
+## What CI proves vs. what doesn't
+
+CI (`.github/workflows/build.yml`) proves: `Infinite.exe` and
+`infinite-vst3-scanner.exe` both compile and link on Windows x64 + ARM64,
+neither imports the VC++ redistributable CRT, and the existing headless
+self-tests still pass on x64 (ARM64 is compile-only, per the workflow's
+existing comment — an x64 runner cannot execute an ARM64 binary).
+
+CI does **not** prove, and none of the following should be claimed as
+working until someone runs it on real Windows hardware:
+- That `EnumerateVST3Plugins`'s folder walk actually finds real bundles.
+- That `ProbeVST3BundleOutOfProcess`/batch actually drains a real child's
+  pipe correctly, honors the timeout, or that `TerminateProcess` cleans up
+  as expected.
+- That the sentinel/blocklist files are actually written/read correctly
+  under `%APPDATA%\Infinite`, or that a real plugin crash gets caught and
+  blocklisted on the next launch.
+- That `LOAD_WITH_ALTERED_SEARCH_PATH` actually resolves a real plugin's
+  sibling DLLs.
+- That `OleInitialize` actually fixes any real drag-drop/file-dialog
+  behavior inside a plugin editor.
+- That the ARM64 arch-folder selection actually finds the right module on a
+  real ARM64 machine.
+
+All of the above: **compiles and links, not runtime-verified.**
+
+## Explicitly not a phase
+
+**Tier 3 SEH guarding** — realtime `process()` calls and plugin instantiation
+are not guardable via `__try`/`__except` the way state and editor calls are
+(`/EHa` does not make a plugin's own corrupted stack recoverable, and
+guarding the audio-thread call would add a filter to the hot path). The
+identical limitation exists on Mac's `sigsetjmp` guard. Only genuine
+out-of-process *hosting* — not just out-of-process scanning — fixes this,
+and that is a far larger architectural change than anything scoped here.
+Keep flagging it; do not implement it.

--- a/package.ps1
+++ b/package.ps1
@@ -15,6 +15,7 @@ $Root  = Split-Path -Parent $MyInvocation.MyCommand.Path
 $Build = Join-Path $Root "build-dist"
 $Stage = Join-Path $Root "dist\Infinite"
 $Exe   = Join-Path $Build "Release\Infinite.exe"
+$ScannerExe = Join-Path $Build "Release\infinite-vst3-scanner.exe"
 
 function Find-VsDevShell {
     $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -60,6 +61,9 @@ if (Test-Path $Stage) { Remove-Item -Recurse -Force $Stage }
 New-Item -ItemType Directory -Force (Split-Path -Parent $Stage) | Out-Null
 New-Item -ItemType Directory -Force $Stage | Out-Null
 Copy-Item $Exe $Stage
+# The out-of-process VST3 scanner (src/scanner_main_win.cpp) must sit next to
+# Infinite.exe - Platform::ScannerExecutablePath() looks for it there.
+if (Test-Path $ScannerExe) { Copy-Item $ScannerExe $Stage }
 
 Write-Host "==> done: $Stage\Infinite.exe"
 if ($Launch) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,11 @@
 #include <sys/stat.h>
 #include "platform/AppPaths.h"
 
+#if defined(_WIN32)
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 namespace
 {
    // Test fixtures live in the OS temp directory; /tmp was hardcoded before
@@ -25348,6 +25353,14 @@ int main(int argc, char** argv)
       // the function's doc comment for why a scanned plugin can otherwise
       // make this child process pop up as a spurious extra Infinite window.
       Platform::SuppressAppUIForScanChild();
+
+#if defined(_WIN32)
+      // stdout defaults to text mode, which translates '\n' to '\r\n' and
+      // corrupts the tab-separated wire format below (the parent's
+      // ParseProbeOutput strips a trailing '\r' defensively as the other
+      // half of this fix).
+      _setmode(_fileno(stdout), _O_BINARY);
+#endif
 
       // Guards the tab-separated wire format below against a plugin whose
       // self-reported name/vendor string happens to contain a tab or newline.

--- a/src/platform/PluginVST3.h
+++ b/src/platform/PluginVST3.h
@@ -33,6 +33,8 @@ namespace Platform
    bool PluginVST3OpenEditor(PluginHandle* handle, std::string& outError);
    void PluginVST3CloseEditor(PluginHandle* handle);
    bool PluginVST3EditorIsOpen(PluginHandle* handle);
+   bool PluginVST3AnyEditorOpen();
+   bool PluginVST3PumpEditorEvents();
 
    bool PluginVST3SaveState(PluginHandle* handle, std::string& outBase64);
    bool PluginVST3RestoreState(PluginHandle* handle, const std::string& base64);

--- a/src/platform/win/PluginHandleInternalWin.h
+++ b/src/platform/win/PluginHandleInternalWin.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// Windows-only Platform::PluginHandle. NOT the same type as
+// src/platform/PluginHandleInternal.h - that header is AU-shaped and
+// unconditionally #imports Cocoa/AudioToolbox/AVFoundation, so it cannot be
+// included here. Windows has no AudioUnit backend at all, so unlike the Mac
+// struct (AU fields with VST3 state bolted on via a sub-pointer) every
+// Windows plugin handle is a VST3 handle or nothing.
+
+#include "../Platform.h"
+#include <string>
+
+namespace Platform
+{
+   // Defined in PluginVST3Win.cpp alongside the rest of the VST3 hosting
+   // machinery (host glue classes, IPtr fields, realtime process data) -
+   // mirroring the PluginHandleInternal.h / PluginVST3.mm split on macOS,
+   // where PluginVST3State is likewise opaque to everything outside that
+   // one translation unit.
+   struct PluginVST3State;
+
+   struct PluginHandle
+   {
+      PluginDesc desc;
+      PluginLoadState state = PluginLoadState::Pending;
+      std::string loadError;
+
+      double sampleRate = 0.0;
+      int maxBlockFrames = 0;
+
+      // Refreshed from IAudioProcessor::getLatencySamples() once
+      // setupProcessing/setActive succeed; read by PluginLatencySamples().
+      int latencySamples = 0;
+
+      // Null for a handle that failed before or without ever touching VST3
+      // (e.g. an AU-format PluginDesc, which Windows can't host at all).
+      PluginVST3State* vst3 = nullptr;
+   };
+}

--- a/src/platform/win/PluginHostWin.cpp
+++ b/src/platform/win/PluginHostWin.cpp
@@ -3,16 +3,17 @@
 //   - Audio Units are macOS-only by definition; there is nothing to enumerate
 //     or host, so EnumerateAudioUnits finds nothing and DescribeAudioUnitBundle
 //     rejects every path.
-//   - VST3 hosting mirrors macOS behind INFINITE_ENABLE_VST3: when the flag is
-//     on, every PluginXxx entry point below dispatches into the Windows VST3
-//     backend (src/platform/win/PluginVST3Win.cpp), which hosts the SDK's
+//   - VST3 hosting mirrors macOS behind INFINITE_ENABLE_VST3 (on by default -
+//     see CMakeLists.txt): when the flag is on, every PluginXxx entry point
+//     below dispatches into the Windows VST3 backend
+//     (src/platform/win/PluginVST3Win.cpp), which hosts the SDK's
 //     IComponent/IEditController/IAudioProcessor directly, including a real
-//     HWND-embedded editor window. Still pending on Windows: full SEH crash
-//     guarding beyond state save/restore and editor calls, and out-of-process
-//     scanning - so EnumerateVST3Plugins/DescribeVST3Bundle stay no-ops here
-//     even with the flag on. When the flag is off (the default - VST3 SDK
-//     licensing, see CMakeLists.txt), every plugin instantiation produces a
-//     Failed-state handle instead.
+//     HWND-embedded editor window, out-of-process scanning via
+//     infinite-vst3-scanner.exe, and sentinel/blocklist crash safety. Still
+//     pending on Windows: full SEH crash guarding beyond state save/restore
+//     and editor calls (Tier 3 - see PluginVST3Win.cpp's header for why that
+//     tier isn't achievable this way at all). When the flag is off, every
+//     plugin instantiation produces a Failed-state handle instead.
 //
 // Every function tolerates a null handle - AudioPluginNode's retire path can
 // hand us one while a topology swap is in flight.
@@ -61,11 +62,9 @@ namespace Platform
       return false;
    }
 
+#if !INFINITE_ENABLE_VST3
    void EnumerateVST3Plugins(const std::vector<std::string>& folders, std::vector<PluginDesc>& out)
    {
-      // Real scanning (targeted rescans, out-of-process isolation) is a
-      // follow-up; for now a plugin is only usable via an already-known
-      // desc.path or a same-session CacheVST3BundlePath hit.
       (void)folders;
       out.clear();
    }
@@ -77,13 +76,11 @@ namespace Platform
       return false;
    }
 
-#if !INFINITE_ENABLE_VST3
    void CacheVST3BundlePath(const std::string& identifier, const std::string& bundlePath)
    {
       (void)identifier;
       (void)bundlePath;
    }
-#endif
 
    void SetVST3SearchFolders(const std::vector<std::string>& folders)
    {
@@ -101,8 +98,13 @@ namespace Platform
    {
       return {};
    }
+#endif // !INFINITE_ENABLE_VST3
 
 #if INFINITE_ENABLE_VST3
+   // EnumerateVST3Plugins, DescribeVST3Bundle, CacheVST3BundlePath,
+   // SetVST3SearchFolders, VST3Blocklist, ClearVST3Blocklist, and
+   // VST3ScanFailures are all defined directly in the Platform namespace by
+   // PluginVST3Win.cpp when the flag is on - nothing to dispatch here.
 
    PluginHandle* PluginCreate(const PluginDesc& desc, double sampleRate, int maxBlockFrames)
    {

--- a/src/platform/win/PluginHostWin.cpp
+++ b/src/platform/win/PluginHostWin.cpp
@@ -6,13 +6,13 @@
 //   - VST3 hosting mirrors macOS behind INFINITE_ENABLE_VST3: when the flag is
 //     on, every PluginXxx entry point below dispatches into the Windows VST3
 //     backend (src/platform/win/PluginVST3Win.cpp), which hosts the SDK's
-//     IComponent/IEditController/IAudioProcessor directly. Still pending on
-//     Windows: the editor window (HWND embedding), full SEH crash guarding
-//     beyond state save/restore, and out-of-process scanning - so
-//     EnumerateVST3Plugins/DescribeVST3Bundle stay no-ops here and
-//     PluginOpenEditor reports unavailable, even with the flag on. When the
-//     flag is off (the default - VST3 SDK licensing, see CMakeLists.txt),
-//     every plugin instantiation produces a Failed-state handle instead.
+//     IComponent/IEditController/IAudioProcessor directly, including a real
+//     HWND-embedded editor window. Still pending on Windows: full SEH crash
+//     guarding beyond state save/restore and editor calls, and out-of-process
+//     scanning - so EnumerateVST3Plugins/DescribeVST3Bundle stay no-ops here
+//     even with the flag on. When the flag is off (the default - VST3 SDK
+//     licensing, see CMakeLists.txt), every plugin instantiation produces a
+//     Failed-state handle instead.
 //
 // Every function tolerates a null handle - AudioPluginNode's retire path can
 // hand us one while a topology swap is in flight.
@@ -242,33 +242,34 @@ namespace Platform
 
    bool PluginOpenEditor(PluginHandle* handle, std::string& outError)
    {
-      // Editor window (HWND embedding) is a separate follow-up session -
-      // report unavailable rather than crash or silently no-op, same as the
-      // no-VST3 build below.
-      (void)handle;
-      outError = "VST3 editor hosting is not yet available on Windows";
-      return false;
+      outError.clear();
+      if (handle == nullptr || handle->vst3 == nullptr)
+      {
+         outError = kUnavailableError;
+         return false;
+      }
+      return PluginVST3OpenEditor(handle, outError);
    }
 
    void PluginCloseEditor(PluginHandle* handle)
    {
-      (void)handle;
+      if (handle != nullptr && handle->vst3 != nullptr)
+         PluginVST3CloseEditor(handle);
    }
 
    bool PluginEditorIsOpen(PluginHandle* handle)
    {
-      (void)handle;
-      return false;
+      return handle != nullptr && handle->vst3 != nullptr && PluginVST3EditorIsOpen(handle);
    }
 
    bool AnyPluginEditorOpen()
    {
-      return false;
+      return PluginVST3AnyEditorOpen();
    }
 
    bool PumpPluginEditorEvents()
    {
-      return false;
+      return PluginVST3PumpEditorEvents();
    }
 
    bool PluginSaveState(PluginHandle* handle, std::string& outBase64)

--- a/src/platform/win/PluginHostWin.cpp
+++ b/src/platform/win/PluginHostWin.cpp
@@ -1,20 +1,18 @@
 // Windows implementation of the Platform facade's audio-plugin surface.
 //
-// This is deliberate graceful degradation, matching how Syphon and Vision are
-// handled elsewhere in the Windows port:
-//
 //   - Audio Units are macOS-only by definition; there is nothing to enumerate
 //     or host, so EnumerateAudioUnits finds nothing and DescribeAudioUnitBundle
 //     rejects every path.
-//   - VST3 hosting stays behind INFINITE_ENABLE_VST3 exactly as on macOS
-//     (licensing: the Steinberg SDK is GPLv3-or-proprietary, this repo is MIT
-//     - see docs/plans/audio/plugin-hosting.md). The Windows build does not
-//     define that macro today: hosting a VST3 for real means the full
-//     IComponent/IEditController/process-adapter layer plus out-of-process
-//     scanning, which is its own project. Everything below reports cleanly
-//     rather than half-working: scans find nothing, instantiation produces a
-//     Failed-state handle whose error text explains why, and the node shows
-//     that status instead of spinning "loading..." forever.
+//   - VST3 hosting mirrors macOS behind INFINITE_ENABLE_VST3: when the flag is
+//     on, every PluginXxx entry point below dispatches into the Windows VST3
+//     backend (src/platform/win/PluginVST3Win.cpp), which hosts the SDK's
+//     IComponent/IEditController/IAudioProcessor directly. Still pending on
+//     Windows: the editor window (HWND embedding), full SEH crash guarding
+//     beyond state save/restore, and out-of-process scanning - so
+//     EnumerateVST3Plugins/DescribeVST3Bundle stay no-ops here and
+//     PluginOpenEditor reports unavailable, even with the flag on. When the
+//     flag is off (the default - VST3 SDK licensing, see CMakeLists.txt),
+//     every plugin instantiation produces a Failed-state handle instead.
 //
 // Every function tolerates a null handle - AudioPluginNode's retire path can
 // hand us one while a topology swap is in flight.
@@ -24,19 +22,30 @@
 #include <string>
 #include <vector>
 
+#if INFINITE_ENABLE_VST3
+#include "PluginHandleInternalWin.h"
+#include "../PluginVST3.h"
+#endif
+
 namespace
 {
    constexpr const char* kUnavailableError =
       "plugin hosting is not available in this build";
+}
 
+#if !INFINITE_ENABLE_VST3
+namespace
+{
    // Minimal concrete handle: exists only so PluginCreate/PluginPoll round-trip
-   // to a clean Failed state instead of crashing or hanging Pending.
+   // to a clean Failed state instead of crashing or hanging Pending, for
+   // builds where INFINITE_ENABLE_VST3 is off.
    struct StubPluginHandle
    {
       Platform::PluginDesc desc;
       bool failedReported = false;
    };
 }
+#endif
 
 namespace Platform
 {
@@ -54,6 +63,9 @@ namespace Platform
 
    void EnumerateVST3Plugins(const std::vector<std::string>& folders, std::vector<PluginDesc>& out)
    {
+      // Real scanning (targeted rescans, out-of-process isolation) is a
+      // follow-up; for now a plugin is only usable via an already-known
+      // desc.path or a same-session CacheVST3BundlePath hit.
       (void)folders;
       out.clear();
    }
@@ -65,11 +77,13 @@ namespace Platform
       return false;
    }
 
+#if !INFINITE_ENABLE_VST3
    void CacheVST3BundlePath(const std::string& identifier, const std::string& bundlePath)
    {
       (void)identifier;
       (void)bundlePath;
    }
+#endif
 
    void SetVST3SearchFolders(const std::vector<std::string>& folders)
    {
@@ -87,6 +101,188 @@ namespace Platform
    {
       return {};
    }
+
+#if INFINITE_ENABLE_VST3
+
+   PluginHandle* PluginCreate(const PluginDesc& desc, double sampleRate, int maxBlockFrames)
+   {
+      if (desc.format == "vst3")
+         return PluginVST3Create(desc, sampleRate, maxBlockFrames);
+
+      // Windows has no AudioUnit backend, so any other format fails cleanly.
+      PluginHandle* h = new PluginHandle();
+      h->desc = desc;
+      h->state = PluginLoadState::Failed;
+      h->loadError = kUnavailableError;
+      return h;
+   }
+
+   PluginLoadState PluginPoll(PluginHandle* handle, std::string& outError)
+   {
+      outError.clear();
+      if (handle == nullptr)
+      {
+         outError = kUnavailableError;
+         return PluginLoadState::Failed;
+      }
+      if (handle->vst3 != nullptr)
+         return PluginVST3Poll(handle, outError);
+      outError = handle->loadError.empty() ? kUnavailableError : handle->loadError;
+      return handle->state;
+   }
+
+   bool PluginPrepare(PluginHandle* handle, double sampleRate, int maxBlockFrames, std::string& outError)
+   {
+      outError.clear();
+      if (handle == nullptr)
+      {
+         outError = kUnavailableError;
+         return false;
+      }
+      if (handle->vst3 != nullptr)
+         return PluginVST3Prepare(handle, sampleRate, maxBlockFrames, outError);
+      outError = kUnavailableError;
+      return false;
+   }
+
+   void PluginDestroy(PluginHandle* handle)
+   {
+      if (handle == nullptr)
+         return;
+      if (handle->vst3 != nullptr)
+      {
+         PluginVST3Destroy(handle); // frees handle too
+         return;
+      }
+      delete handle;
+   }
+
+   PluginDesc PluginDescriptionOf(PluginHandle* handle)
+   {
+      return handle != nullptr ? handle->desc : PluginDesc();
+   }
+
+   int PluginLatencySamples(PluginHandle* handle)
+   {
+      return handle != nullptr ? handle->latencySamples : 0;
+   }
+
+   void PluginRender(PluginHandle* handle, const float* const* in, int inChannels,
+                     float* const* out, int outChannels, int numFrames)
+   {
+      if (handle != nullptr && handle->vst3 != nullptr)
+      {
+         PluginVST3Render(handle, in, inChannels, out, outChannels, numFrames);
+         return;
+      }
+      (void)in;
+      (void)inChannels;
+      for (int ch = 0; ch < outChannels; ch++)
+      {
+         if (out[ch] != nullptr)
+         {
+            for (int i = 0; i < numFrames; i++)
+               out[ch][i] = 0.0f;
+         }
+      }
+   }
+
+   void PluginScheduleMIDIEvent(PluginHandle* handle, int frameOffset,
+                                const unsigned char* bytes, int byteCount)
+   {
+      if (handle != nullptr && handle->vst3 != nullptr)
+         PluginVST3ScheduleMIDIEvent(handle, frameOffset, bytes, byteCount);
+   }
+
+   int PluginParameterCount(PluginHandle* handle)
+   {
+      return (handle != nullptr && handle->vst3 != nullptr) ? PluginVST3ParameterCount(handle) : 0;
+   }
+
+   bool PluginParameterInfo(PluginHandle* handle, int index, PluginParamInfo& out)
+   {
+      return (handle != nullptr && handle->vst3 != nullptr) && PluginVST3ParameterInfo(handle, index, out);
+   }
+
+   bool PluginParameterInfoByAddress(PluginHandle* handle, unsigned long long address,
+                                     PluginParamInfo& out)
+   {
+      return (handle != nullptr && handle->vst3 != nullptr) &&
+             PluginVST3ParameterInfoByAddress(handle, address, out);
+   }
+
+   void PluginSetParameter(PluginHandle* handle, unsigned long long address, float value)
+   {
+      if (handle != nullptr && handle->vst3 != nullptr)
+         PluginVST3SetParameter(handle, address, value);
+   }
+
+   bool PluginGetParameter(PluginHandle* handle, unsigned long long address, float& outValue)
+   {
+      outValue = 0.0f;
+      return (handle != nullptr && handle->vst3 != nullptr) && PluginVST3GetParameter(handle, address, outValue);
+   }
+
+   void PluginBeginLearn(PluginHandle* handle)
+   {
+      if (handle != nullptr && handle->vst3 != nullptr)
+         PluginVST3BeginLearn(handle);
+   }
+
+   void PluginEndLearn(PluginHandle* handle)
+   {
+      if (handle != nullptr && handle->vst3 != nullptr)
+         PluginVST3EndLearn(handle);
+   }
+
+   bool PluginPollLearned(PluginHandle* handle, unsigned long long& outAddress)
+   {
+      return (handle != nullptr && handle->vst3 != nullptr) && PluginVST3PollLearned(handle, outAddress);
+   }
+
+   bool PluginOpenEditor(PluginHandle* handle, std::string& outError)
+   {
+      // Editor window (HWND embedding) is a separate follow-up session -
+      // report unavailable rather than crash or silently no-op, same as the
+      // no-VST3 build below.
+      (void)handle;
+      outError = "VST3 editor hosting is not yet available on Windows";
+      return false;
+   }
+
+   void PluginCloseEditor(PluginHandle* handle)
+   {
+      (void)handle;
+   }
+
+   bool PluginEditorIsOpen(PluginHandle* handle)
+   {
+      (void)handle;
+      return false;
+   }
+
+   bool AnyPluginEditorOpen()
+   {
+      return false;
+   }
+
+   bool PumpPluginEditorEvents()
+   {
+      return false;
+   }
+
+   bool PluginSaveState(PluginHandle* handle, std::string& outBase64)
+   {
+      outBase64.clear();
+      return (handle != nullptr && handle->vst3 != nullptr) && PluginVST3SaveState(handle, outBase64);
+   }
+
+   bool PluginRestoreState(PluginHandle* handle, const std::string& base64)
+   {
+      return (handle != nullptr && handle->vst3 != nullptr) && PluginVST3RestoreState(handle, base64);
+   }
+
+#else // !INFINITE_ENABLE_VST3
 
    PluginHandle* PluginCreate(const PluginDesc& desc, double sampleRate, int maxBlockFrames)
    {
@@ -148,6 +344,7 @@ namespace Platform
    void PluginRender(PluginHandle* handle, const float* const* in, int inChannels,
                      float* const* out, int outChannels, int numFrames)
    {
+      (void)handle;
       (void)in;
       (void)inChannels;
       // Silence out: a Failed-state plugin never reaches ProcessBlock in the
@@ -267,4 +464,6 @@ namespace Platform
       (void)base64;
       return false;
    }
+
+#endif // INFINITE_ENABLE_VST3
 }

--- a/src/platform/win/PluginVST3Win.cpp
+++ b/src/platform/win/PluginVST3Win.cpp
@@ -57,7 +57,6 @@ namespace
 {
    namespace fs = std::filesystem;
 
-   void VST3Trace(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
    void VST3Trace(const char* fmt, ...)
    {
       static const bool enabled = getenv("INFINITE_VST3TRACE") != nullptr;

--- a/src/platform/win/PluginVST3Win.cpp
+++ b/src/platform/win/PluginVST3Win.cpp
@@ -1,14 +1,14 @@
 // Windows VST3 hosting - the portable ~75% of PluginVST3.mm (host glue
 // classes, create/init/process/parameter/state logic) ported essentially
 // unchanged, plus the genuinely Windows-specific pieces that are actually
-// needed for anything to instantiate at all (DLL loading, UTF-16 handling).
+// needed for anything to instantiate at all (DLL loading, UTF-16 handling),
+// plus real editor-window (HWND) hosting with the same Tier-2 SEH crash-guard
+// discipline used for state save/restore.
 //
 // Deliberately NOT ported in this phase (see the plan for the follow-up
 // sessions each of these becomes):
-//   - Editor window (HWND creation/embedding, kPlatformTypeHWND, resize).
-//     PluginVST3OpenEditor below stubs this out cleanly.
-//   - SEH crash guarding beyond state save/restore. Editor-related guarding
-//     has nothing to guard yet since there's no editor to open.
+//   - SEH crash guarding of realtime/instantiation calls (Tier 3 - not
+//     guardable this way; would need out-of-process hosting).
 //   - Out-of-process scanning, sentinel/blocklist persistence. Enumeration
 //     stays routed through PluginHostWin.cpp's existing no-op, so bundle
 //     resolution below only ever succeeds via desc.path or a same-session
@@ -1027,6 +1027,49 @@ namespace
       Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mSrc;
       Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mDst;
    };
+
+   // ------------------------------------------------------------------------
+   // Host-side IPlugFrame - required so a plugin's resizable GUI can ask us
+   // to resize its window. Without this, resizeView() has no host object to
+   // call, and a resizable-GUI plugin either can't resize or crashes trying.
+   // ------------------------------------------------------------------------
+   class HostPlugFrame : public Steinberg::IPlugFrame
+   {
+   public:
+      explicit HostPlugFrame(Platform::PluginHandle* handle) : mHandle(handle) {}
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::IPlugFrame::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::tresult PLUGIN_API resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override;
+
+      void detach() { mHandle = nullptr; }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      Platform::PluginHandle* mHandle = nullptr;
+   };
 }
 
 namespace Platform
@@ -1092,7 +1135,41 @@ namespace Platform
       // Set once a crash guard catches this instance faulting inside
       // getState/setState. See RunPluginCallGuarded below.
       std::atomic<bool> stateCallsUnstable { false };
+
+      // Editor window state. Windows equivalent of the NSWindow/delegate
+      // pair on PluginVST3.mm's PluginHandle - kept here instead, on the
+      // opaque VST3-only state, because the process-wide open-editor
+      // counter (gWinOpenPluginEditorCount, below) lives in this file
+      // rather than in a shared Platform.mm the way Mac's does.
+      HWND editorHwnd = nullptr;
+      Steinberg::IPtr<HostPlugFrame> plugFrame;
+      std::atomic<bool> editorOpen { false };
+
+      // Distinguishes the host resizing the HWND because the plugin asked
+      // (HostPlugFrame::resizeView) from the user dragging the window's own
+      // resize border - SetWindowPos synchronously delivers WM_SIZE back
+      // into the same WndProc before it returns, so without this flag
+      // onSize() would be called twice for one logical resize.
+      bool resizingFromPlugin = false;
+
+      // Set once a crash guard catches this instance faulting inside
+      // createView/getSize/attached/onSize. Independent from
+      // stateCallsUnstable - a plugin can have a broken editor and a
+      // perfectly fine getState(), or vice versa.
+      std::atomic<bool> editorUnstable { false };
    };
+
+   // Defined further down, alongside the rest of the crash-guard machinery;
+   // forward-declared here (inside the same unnamed namespace nested in
+   // Platform, which is shared across the whole translation unit) so it can
+   // be used ahead of that point - by PluginVST3Destroy below, and by
+   // HostPlugFrame::resizeView, which needs to call it but lives in a
+   // different (global-scope) unnamed namespace and so must reach this one
+   // through the qualified name Platform::RunPluginCallGuarded.
+   namespace
+   {
+      bool RunPluginCallGuarded(const char* what, PluginHandle* h, const std::function<void()>& fn);
+   }
 }
 
 namespace
@@ -1105,6 +1182,43 @@ namespace
          return;
       mHandle->vst3->learnedAddress.store((unsigned long long)id, std::memory_order_relaxed);
       mHandle->vst3->learnedValid.store(true, std::memory_order_release);
+   }
+
+   Steinberg::tresult PLUGIN_API HostPlugFrame::resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize)
+   {
+      if (mHandle == nullptr || mHandle->vst3 == nullptr || newSize == nullptr)
+         return Steinberg::kResultFalse;
+      Platform::PluginVST3State* v = mHandle->vst3;
+      // Editor may already be gone (window closed, or this call landed
+      // after teardown) - the plugin's timer can fire against
+      // half-torn-down state.
+      if (v->editorHwnd == nullptr || v->plugView != view)
+         return Steinberg::kResultFalse;
+
+      const int width = newSize->right - newSize->left;
+      const int height = newSize->bottom - newSize->top;
+      if (width <= 0 || height <= 0)
+         return Steinberg::kResultFalse;
+
+      RECT rect = { 0, 0, width, height };
+      const DWORD style = (DWORD)GetWindowLongPtrW(v->editorHwnd, GWL_STYLE);
+      const DWORD exStyle = (DWORD)GetWindowLongPtrW(v->editorHwnd, GWL_EXSTYLE);
+      AdjustWindowRectEx(&rect, style, FALSE, exStyle);
+
+      v->resizingFromPlugin = true;
+      SetWindowPos(v->editorHwnd, nullptr, 0, 0, rect.right - rect.left, rect.bottom - rect.top,
+                   SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+
+      // Per IPlugFrame::resizeView's own doc comment: the host must call
+      // IPlugView::onSize() after handling the resize.
+      const bool ok = Platform::RunPluginCallGuarded("onSize", mHandle, [&] { view->onSize(newSize); });
+      v->resizingFromPlugin = false;
+      if (!ok)
+      {
+         v->editorUnstable.store(true, std::memory_order_relaxed);
+         return Steinberg::kResultFalse;
+      }
+      return Steinberg::kResultTrue;
    }
 
    using GetPluginFactoryProc = Steinberg::IPluginFactory* (*)();
@@ -1178,6 +1292,88 @@ namespace
       if (outFactory != nullptr)
          *outFactory = factory;
       return module;
+   }
+
+   // ------------------------------------------------------------------------
+   // Editor window plumbing.
+   //
+   // Process-wide count of open plugin editor windows, kept in lockstep with
+   // every PluginVST3State's editorOpen flag (see SetPluginEditorOpenWin
+   // below) so PluginVST3AnyEditorOpen() is a cheap atomic read rather than a
+   // walk over every handle.
+   // ------------------------------------------------------------------------
+   std::atomic<int> gWinOpenPluginEditorCount { 0 };
+
+   void SetPluginEditorOpenWin(Platform::PluginHandle* h, bool open)
+   {
+      if (h == nullptr || h->vst3 == nullptr)
+         return;
+      bool was = h->vst3->editorOpen.exchange(open, std::memory_order_acq_rel);
+      if (was == open)
+         return;
+      if (open)
+         gWinOpenPluginEditorCount.fetch_add(1, std::memory_order_relaxed);
+      else
+         gWinOpenPluginEditorCount.fetch_sub(1, std::memory_order_relaxed);
+   }
+
+   constexpr wchar_t kEditorWindowClassName[] = L"InfinitePluginEditorWindow";
+
+   // User clicked the window's own close button (or Alt-F4'd it). Treated
+   // the same as the node's "close" toggle (PluginVST3CloseEditor's
+   // counterpart on Mac): soft-close only - hide the window, flip the open
+   // flag, but leave plugView/editorHwnd alive so reopening just re-shows
+   // the plugin's real editor instead of re-requesting a view a second time.
+   // Real teardown only happens in PluginVST3CloseEditor/PluginVST3Destroy.
+   LRESULT CALLBACK PluginEditorWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+   {
+      if (msg == WM_NCCREATE)
+      {
+         auto* createStruct = reinterpret_cast<CREATESTRUCTW*>(lParam);
+         SetWindowLongPtrW(hwnd, GWLP_USERDATA, (LONG_PTR)createStruct->lpCreateParams);
+         return DefWindowProcW(hwnd, msg, wParam, lParam);
+      }
+
+      auto* h = reinterpret_cast<Platform::PluginHandle*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+
+      if (msg == WM_CLOSE)
+      {
+         SetPluginEditorOpenWin(h, false);
+         ShowWindow(hwnd, SW_HIDE);
+         return 0;
+      }
+
+      if (msg == WM_SIZE)
+      {
+         if (h != nullptr && h->vst3 != nullptr && h->vst3->plugView && !h->vst3->resizingFromPlugin &&
+             wParam != SIZE_MINIMIZED)
+         {
+            RECT client = {};
+            GetClientRect(hwnd, &client);
+            Steinberg::ViewRect newSize(0, 0, client.right - client.left, client.bottom - client.top);
+            Platform::PluginVST3State* v = h->vst3;
+            if (!Platform::RunPluginCallGuarded("onSize", h, [&] { v->plugView->onSize(&newSize); }))
+               v->editorUnstable.store(true, std::memory_order_relaxed);
+         }
+         return DefWindowProcW(hwnd, msg, wParam, lParam);
+      }
+
+      return DefWindowProcW(hwnd, msg, wParam, lParam);
+   }
+
+   ATOM RegisterEditorWindowClassOnce()
+   {
+      static const ATOM atom = [] {
+         WNDCLASSEXW wc = {};
+         wc.cbSize = sizeof(wc);
+         wc.style = CS_HREDRAW | CS_VREDRAW;
+         wc.lpfnWndProc = PluginEditorWndProc;
+         wc.hInstance = GetModuleHandleW(nullptr);
+         wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+         wc.lpszClassName = kEditorWindowClassName;
+         return RegisterClassExW(&wc);
+      }();
+      return atom;
    }
 }
 
@@ -1587,12 +1783,28 @@ namespace Platform
 
       PluginVST3State* v = h->vst3;
 
-      // No editor window teardown here (editor hosting isn't ported this
-      // phase - see PluginVST3OpenEditor below), so v->plugView is always
-      // null in practice; guarded anyway in case that changes.
+      // removed() must happen while the editor HWND is still alive - detach
+      // the plugin from its view first, only then tear down the window it
+      // was living in. (Guarded: a plugin whose editor already faulted once
+      // can fault again here.)
       if (v->plugView)
       {
+         RunPluginCallGuarded("removed", h, [&] { v->plugView->removed(); });
          v->plugView = nullptr;
+      }
+
+      if (v->editorHwnd != nullptr)
+      {
+         HWND hwnd = v->editorHwnd;
+         v->editorHwnd = nullptr;
+         SetPluginEditorOpenWin(h, false);
+         DestroyWindow(hwnd);
+      }
+
+      if (v->plugFrame)
+      {
+         v->plugFrame->detach();
+         v->plugFrame = nullptr;
       }
 
       if (v->compToCtrlProxy)
@@ -1901,27 +2113,163 @@ namespace Platform
    }
 
    // ------------------------------------------------------------------------
-   // Editor window - not ported this phase. HWND creation/embedding via
-   // kPlatformTypeHWND is real, substantial work (see the plan) and becomes
-   // its own follow-up session.
+   // Editor Window
    // ------------------------------------------------------------------------
 
    bool PluginVST3OpenEditor(PluginHandle* h, std::string& outError)
    {
-      (void)h;
-      outError = "VST3 editor hosting is not yet available on Windows";
-      return false;
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller || h->state != PluginLoadState::Ready)
+      {
+         outError = "plugin not loaded";
+         return false;
+      }
+      PluginVST3State* v = h->vst3;
+
+      if (v->editorUnstable.load(std::memory_order_relaxed))
+      {
+         outError = "plugin's editor crashed previously and is disabled for this session";
+         return false;
+      }
+
+      if (v->editorHwnd != nullptr)
+      {
+         ShowWindow(v->editorHwnd, SW_SHOW);
+         SetForegroundWindow(v->editorHwnd);
+         SetPluginEditorOpenWin(h, true);
+         return true;
+      }
+
+      if (!v->plugView)
+      {
+         Steinberg::IPlugView* view = nullptr;
+         if (!RunPluginCallGuarded("createView", h, [&] { view = v->controller->createView(Steinberg::Vst::ViewType::kEditor); }))
+         {
+            v->editorUnstable.store(true, std::memory_order_relaxed);
+            outError = "plugin crashed creating its editor view";
+            return false;
+         }
+         if (view == nullptr)
+         {
+            outError = "plugin has no custom GUI editor";
+            return false;
+         }
+         v->plugView = Steinberg::owned(view);
+      }
+
+      Steinberg::ViewRect rect = {};
+      if (!RunPluginCallGuarded("getSize", h, [&] { v->plugView->getSize(&rect); }))
+      {
+         v->editorUnstable.store(true, std::memory_order_relaxed);
+         outError = "plugin crashed sizing its editor view";
+         return false;
+      }
+      int width = rect.right - rect.left;
+      int height = rect.bottom - rect.top;
+      if (width < 120 || height < 80)
+      {
+         width = 640;
+         height = 420;
+      }
+
+      bool canResize = false;
+      RunPluginCallGuarded("canResize", h, [&] { canResize = v->plugView->canResize() == Steinberg::kResultTrue; });
+
+      RegisterEditorWindowClassOnce();
+
+      DWORD style = WS_OVERLAPPEDWINDOW;
+      if (!canResize)
+         style &= ~(WS_THICKFRAME | WS_MAXIMIZEBOX);
+
+      RECT wr = { 0, 0, width, height };
+      AdjustWindowRectEx(&wr, style, FALSE, 0);
+
+      HWND hwnd = CreateWindowExW(0, kEditorWindowClassName, WinCommon::Utf8ToWide(h->desc.name).c_str(),
+                                  style, CW_USEDEFAULT, CW_USEDEFAULT, wr.right - wr.left, wr.bottom - wr.top,
+                                  nullptr, nullptr, GetModuleHandleW(nullptr), h);
+      if (hwnd == nullptr)
+      {
+         outError = "failed to create editor window";
+         return false;
+      }
+
+      // Spec requires setFrame() before attached() - it is how a plugin with
+      // a resizable GUI learns who to ask for a resize. Serum2 relies on
+      // this (calls plugFrame->resizeView() from its own GUI timer).
+      if (!v->plugFrame)
+         v->plugFrame = Steinberg::owned(new HostPlugFrame(h));
+      if (!RunPluginCallGuarded("setFrame", h, [&] { v->plugView->setFrame(v->plugFrame); }))
+      {
+         v->editorUnstable.store(true, std::memory_order_relaxed);
+         outError = "plugin crashed setting its editor frame";
+         DestroyWindow(hwnd);
+         return false;
+      }
+
+      if (!RunPluginCallGuarded("attached", h, [&] { v->plugView->attached((void*)hwnd, Steinberg::kPlatformTypeHWND); }))
+      {
+         v->editorUnstable.store(true, std::memory_order_relaxed);
+         outError = "plugin crashed opening its editor";
+         // The plugin may already have installed GUI timers/observers by
+         // this point (this is exactly the Serum2 crash shape: a fault mid-
+         // attached() leaves them armed against half-constructed state).
+         // removed() first while the window is still alive, then tear down
+         // the window - not the reverse.
+         RunPluginCallGuarded("removed", h, [&] { v->plugView->removed(); });
+         v->plugView = nullptr;
+         DestroyWindow(hwnd);
+         return false;
+      }
+
+      v->editorHwnd = hwnd;
+      ShowWindow(hwnd, SW_SHOW);
+      SetForegroundWindow(hwnd);
+      SetPluginEditorOpenWin(h, true);
+      return true;
    }
 
    void PluginVST3CloseEditor(PluginHandle* h)
    {
-      (void)h;
+      if (h == nullptr || h->vst3 == nullptr || h->vst3->editorHwnd == nullptr)
+         return;
+      PluginVST3State* v = h->vst3;
+
+      // Fully detach, not just hide: a merely-hidden window left the
+      // plugin's view attached() and its GUI timer armed indefinitely.
+      // removed() first while the window is still alive, matching the same
+      // ordering used on the attached()-failure and destroy paths.
+      if (v->plugView)
+      {
+         RunPluginCallGuarded("removed", h, [&] { v->plugView->removed(); });
+         v->plugView = nullptr;
+      }
+
+      HWND hwnd = v->editorHwnd;
+      v->editorHwnd = nullptr;
+      SetPluginEditorOpenWin(h, false);
+      DestroyWindow(hwnd);
    }
 
    bool PluginVST3EditorIsOpen(PluginHandle* h)
    {
-      (void)h;
-      return false;
+      return h != nullptr && h->vst3 != nullptr && h->vst3->editorOpen.load(std::memory_order_acquire);
+   }
+
+   bool PluginVST3AnyEditorOpen()
+   {
+      return gWinOpenPluginEditorCount.load(std::memory_order_relaxed) > 0;
+   }
+
+   bool PluginVST3PumpEditorEvents()
+   {
+      MSG msg;
+      bool any = false;
+      while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+      {
+         any = true;
+         TranslateMessage(&msg);
+         DispatchMessageW(&msg);
+      }
+      return any;
    }
 
    // ------------------------------------------------------------------------

--- a/src/platform/win/PluginVST3Win.cpp
+++ b/src/platform/win/PluginVST3Win.cpp
@@ -5,15 +5,16 @@
 // plus real editor-window (HWND) hosting with the same Tier-2 SEH crash-guard
 // discipline used for state save/restore.
 //
+// Also hosts the out-of-process scanning + crash-safety machinery
+// (EnumerateVST3Plugins, DescribeVST3Bundle, the sentinel/blocklist pair
+// under %APPDATA%\Infinite), ported from PluginVST3.mm's equivalent section
+// with CreateProcessW/pipes standing in for posix_spawn/select and
+// crude_json standing in for the same JSON blocklist format.
+//
 // Deliberately NOT ported in this phase (see the plan for the follow-up
 // sessions each of these becomes):
 //   - SEH crash guarding of realtime/instantiation calls (Tier 3 - not
 //     guardable this way; would need out-of-process hosting).
-//   - Out-of-process scanning, sentinel/blocklist persistence. Enumeration
-//     stays routed through PluginHostWin.cpp's existing no-op, so bundle
-//     resolution below only ever succeeds via desc.path or a same-session
-//     cache hit - never a fresh disk scan. This is a known, called-out gap,
-//     not a silent regression.
 
 #include "PluginVST3.h"
 
@@ -22,8 +23,13 @@
 #include "PluginHandleInternalWin.h"
 #include "WinCommon.h"
 
+#include <objbase.h>
+#include <ole2.h>
+#include <io.h>
+
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstdarg>
 #include <cstdio>
@@ -35,6 +41,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "crude_json.h"
 
 #include "pluginterfaces/base/funknown.h"
 #include "pluginterfaces/base/ibstream.h"
@@ -225,10 +233,10 @@ namespace
 
 namespace Platform
 {
-   // Identifier -> bundle path cache, exactly as PluginVST3.mm's. Real disk
-   // scanning isn't ported yet (see file header), so this only ever gets
-   // populated from a desc.path that resolved successfully - still useful
-   // for re-resolving the same plugin later in the same process run.
+   // Identifier -> bundle path cache, exactly as PluginVST3.mm's. Populated
+   // both by a desc.path that resolved successfully and by every class
+   // DescribeVST3Bundle finds during a scan, so it is the thing a later
+   // resolve-by-identifier actually hits.
    static std::mutex gBundleMapMutex;
    static std::unordered_map<std::string, std::string> gVST3BundleMap;
 
@@ -243,6 +251,701 @@ namespace Platform
       std::lock_guard<std::mutex> lock(gBundleMapMutex);
       auto it = gVST3BundleMap.find(identifier);
       return it != gVST3BundleMap.end() ? it->second : std::string();
+   }
+}
+
+namespace
+{
+   namespace fsProbe = std::filesystem;
+
+   // ------------------------------------------------------------------------
+   // User-added VST3 search folders - mirrors PluginVST3.mm's
+   // gExtraVST3SearchFolders exactly (same call site: PluginScanner::Folders()
+   // via Platform::SetVST3SearchFolders).
+   // ------------------------------------------------------------------------
+   std::mutex gSearchFoldersMutex;
+   std::vector<std::string> gExtraVST3SearchFolders;
+
+   std::vector<std::string> GetExtraVST3SearchFolders()
+   {
+      std::lock_guard<std::mutex> lock(gSearchFoldersMutex);
+      return gExtraVST3SearchFolders;
+   }
+
+   // ------------------------------------------------------------------------
+   // Crash-safety: sentinel + blocklist
+   //
+   // DescribeVST3Bundle loads an arbitrary third party's compiled code
+   // in-process (LoadLibraryExW -> InitDll -> read factory -> ExitDll). A
+   // hostile or simply broken bundle can access-violate or abort from inside
+   // that call, which a C++ try/catch cannot intercept (and even SEH cannot
+   // safely recover a corrupted CRT heap from - see the Tier 3 note at the
+   // top of this file). The sentinel records which bundle is being probed
+   // *before* the call, so if this process is dead the next time the app
+   // launches, the last-probed path is still sitting in the sentinel file and
+   // gets blocklisted rather than killing every future scan the same way.
+   // Exact port of PluginVST3.mm's equivalent section, %APPDATA%\Infinite
+   // standing in for ~/Library/Application Support/Infinite.
+   // ------------------------------------------------------------------------
+
+   std::string SettingsDirForVST3()
+   {
+      wchar_t* appData = nullptr;
+      size_t len = 0;
+      if (_wdupenv_s(&appData, &len, L"APPDATA") != 0 || appData == nullptr)
+         return {};
+      std::wstring appDataW(appData);
+      free(appData);
+      if (appDataW.empty())
+         return {};
+      std::wstring dirW = appDataW + L"\\Infinite";
+      if (getenv("INFINITE_PLUGINDRAGTEST") != nullptr)
+         dirW += L"\\plugin_drag_test";
+      CreateDirectoryW(appDataW.c_str(), nullptr);
+      CreateDirectoryW(dirW.c_str(), nullptr);
+      return WinCommon::WideToUtf8(dirW);
+   }
+
+   std::string VST3SentinelPath()
+   {
+      const std::string dir = SettingsDirForVST3();
+      return dir.empty() ? std::string() : dir + "\\PluginScanSentinel.txt";
+   }
+
+   std::string VST3BlocklistPath()
+   {
+      const std::string dir = SettingsDirForVST3();
+      return dir.empty() ? std::string() : dir + "\\PluginVST3Blocklist.json";
+   }
+
+   std::mutex gVST3SafetyMutex; // guards gBlocklist and every sentinel/failure op below
+   std::vector<std::string> gBlocklist;
+   std::vector<std::string> gScanFailures;
+   bool gBlocklistLoaded = false;
+
+   void LoadBlocklistLocked()
+   {
+      if (gBlocklistLoaded)
+         return;
+      gBlocklistLoaded = true;
+      const std::string path = VST3BlocklistPath();
+      if (path.empty())
+         return;
+      auto [json, ok] = crude_json::value::load(path);
+      if (!ok || !json.is_array())
+         return;
+      for (const crude_json::value& v : json.get<crude_json::array>())
+         if (v.is_string())
+            gBlocklist.push_back(v.get<crude_json::string>());
+   }
+
+   void SaveBlocklistLocked()
+   {
+      const std::string path = VST3BlocklistPath();
+      if (path.empty())
+         return;
+      crude_json::value json = crude_json::array {};
+      for (const std::string& p : gBlocklist)
+         json.push_back(crude_json::value(p));
+      json.save(path, 2);
+   }
+
+   // Checked once per process, before the first bundle is ever probed: if the
+   // previous run's sentinel is still sitting there non-empty, that run died
+   // mid-probe of that exact bundle.
+   void CheckSentinelForCrashLocked()
+   {
+      const std::string path = VST3SentinelPath();
+      if (path.empty())
+         return;
+      FILE* f = std::fopen(path.c_str(), "rb");
+      if (f == nullptr)
+         return;
+      char buf[4096] = {};
+      size_t n = std::fread(buf, 1, sizeof(buf) - 1, f);
+      std::fclose(f);
+      if (n == 0)
+         return;
+      std::string crashed(buf, n);
+      while (!crashed.empty() && (crashed.back() == '\n' || crashed.back() == '\r'))
+         crashed.pop_back();
+      if (crashed.empty())
+         return;
+
+      LoadBlocklistLocked();
+      if (std::find(gBlocklist.begin(), gBlocklist.end(), crashed) == gBlocklist.end())
+      {
+         VST3Trace("sentinel found non-empty at startup - blocklisting: %s", crashed.c_str());
+         gBlocklist.push_back(crashed);
+         SaveBlocklistLocked();
+      }
+      std::remove(path.c_str());
+   }
+
+   void EnsureSentinelCheckedOnce()
+   {
+      static std::once_flag once;
+      std::call_once(once, [] {
+         std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+         CheckSentinelForCrashLocked();
+      });
+   }
+
+   bool IsBlocklistedPath(const std::string& bundlePath)
+   {
+      std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+      LoadBlocklistLocked();
+      return std::find(gBlocklist.begin(), gBlocklist.end(), bundlePath) != gBlocklist.end();
+   }
+
+   // Written+flushed just before the in-process probe, cleared right after a
+   // clean return (success or ordinary failure). Deliberately not RAII: the
+   // whole point is to survive the case where the destructor never runs.
+   // _commit() is fsync()'s Windows equivalent - without it the write can
+   // still be sitting in the OS cache (never mind app-level buffering) at the
+   // moment a crashing plugin takes this process down with it.
+   void WriteSentinel(const std::string& bundlePath)
+   {
+      const std::string path = VST3SentinelPath();
+      if (path.empty())
+         return;
+      FILE* f = std::fopen(path.c_str(), "wb");
+      if (f == nullptr)
+         return;
+      std::fwrite(bundlePath.data(), 1, bundlePath.size(), f);
+      std::fflush(f);
+      _commit(_fileno(f));
+      std::fclose(f);
+   }
+
+   void ClearSentinel()
+   {
+      const std::string path = VST3SentinelPath();
+      if (!path.empty())
+         std::remove(path.c_str());
+   }
+
+   void RecordScanFailure(const std::string& bundlePath)
+   {
+      std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+      gScanFailures.push_back(bundlePath);
+   }
+
+   // Adds a bundle to the persisted blocklist immediately, in the same scan
+   // that caught it crashing/hanging - unlike the sentinel path above (which
+   // only catches a crash on the *next* launch), this fires the moment
+   // ProbeVST3BundleOutOfProcess sees a dead or unresponsive child.
+   void AddToBlocklistLocked(const std::string& bundlePath)
+   {
+      LoadBlocklistLocked();
+      if (std::find(gBlocklist.begin(), gBlocklist.end(), bundlePath) == gBlocklist.end())
+      {
+         gBlocklist.push_back(bundlePath);
+         SaveBlocklistLocked();
+      }
+   }
+
+   // ------------------------------------------------------------------------
+   // Out-of-process bundle probing
+   //
+   // DescribeVST3Bundle runs arbitrary third-party code in-process and is only
+   // safe to call directly from the "--vst3-scan-bundle" child mode in
+   // main.cpp, or from the dedicated infinite-vst3-scanner.exe's own main
+   // (src/scanner_main_win.cpp), where a crash costs one disposable process.
+   // EnumerateVST3Plugins below re-execs one of those binaries once per batch
+   // instead of calling DescribeVST3Bundle itself, so a crashing or hanging
+   // plugin never takes the scan - or the app - down with it.
+   // ------------------------------------------------------------------------
+
+   enum class ProbeOutcome
+   {
+      Success,   // child exited cleanly and described at least one class
+      CleanMiss, // child exited cleanly but found nothing usable - not a crash
+      Crashed,   // child was terminated, exited nonzero, or hung
+   };
+
+   // The child's stdout is text-mode by default on Windows, which would
+   // translate every '\n' it writes to '\r\n' and corrupt this tab-separated
+   // format (see the file-header note on _setmode in scanner_main_win.cpp and
+   // main.cpp's --vst3-scan-bundle child). Stripping a trailing '\r' here is
+   // the defensive second half of that fix - it means a stray un-fixed
+   // stdout somewhere still parses correctly instead of silently reporting
+   // every plugin as non-instrument (acceptsNotes == "1\r" != "1").
+   std::vector<Platform::PluginDesc> ParseProbeOutput(const std::string& output)
+   {
+      std::vector<Platform::PluginDesc> out;
+      size_t pos = 0;
+      while (pos < output.size())
+      {
+         size_t nl = output.find('\n', pos);
+         std::string line = output.substr(pos, nl == std::string::npos ? std::string::npos : nl - pos);
+         pos = (nl == std::string::npos) ? output.size() : nl + 1;
+         if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+         if (line.empty())
+            continue;
+
+         std::vector<std::string> fields;
+         size_t p = 0;
+         while (true)
+         {
+            size_t tab = line.find('\t', p);
+            fields.push_back(line.substr(p, tab == std::string::npos ? std::string::npos : tab - p));
+            if (tab == std::string::npos)
+               break;
+            p = tab + 1;
+         }
+         if (fields.size() != 6)
+            continue;
+
+         Platform::PluginDesc d;
+         d.format = fields[0];
+         d.name = fields[1];
+         d.manufacturer = fields[2];
+         d.identifier = fields[3];
+         d.path = fields[4];
+         d.acceptsNotes = fields[5] == "1";
+         out.push_back(std::move(d));
+      }
+      return out;
+   }
+
+   // Reads everything currently available from a non-blocking-mode pipe
+   // without blocking, using PeekNamedPipe to check for data first (an
+   // anonymous pipe's read handle can't be put in true overlapped/async
+   // mode). Returns false once the child has closed its write end (EOF) or
+   // the deadline passes.
+   struct DrainResult
+   {
+      std::string output;
+      bool timedOut = false;
+   };
+
+   DrainResult DrainChildStdout(HANDLE readHandle, HANDLE processHandle,
+                                 std::chrono::steady_clock::time_point deadline)
+   {
+      DrainResult result;
+      char buf[4096];
+      for (;;)
+      {
+         if (std::chrono::steady_clock::now() >= deadline)
+         {
+            result.timedOut = true;
+            break;
+         }
+
+         DWORD available = 0;
+         if (!PeekNamedPipe(readHandle, nullptr, 0, nullptr, &available, nullptr))
+            break; // pipe broken - child exited and closed its handle
+
+         if (available == 0)
+         {
+            // Nothing to read yet; poll rather than block so the deadline
+            // above is still honored against a hung child. Also bail out
+            // early if the child has already exited (WAIT_OBJECT_0) even
+            // though its handle might briefly linger.
+            if (WaitForSingleObject(processHandle, 0) == WAIT_OBJECT_0)
+            {
+               // Drain any final bytes written right before exit, then stop.
+               if (PeekNamedPipe(readHandle, nullptr, 0, nullptr, &available, nullptr) && available > 0)
+                  continue;
+               break;
+            }
+            Sleep(5);
+            continue;
+         }
+
+         DWORD toRead = (DWORD)std::min((size_t)available, sizeof(buf));
+         DWORD read = 0;
+         if (!ReadFile(readHandle, buf, toRead, &read, nullptr) || read == 0)
+            break;
+         result.output.append(buf, read);
+      }
+      return result;
+   }
+
+   // Spawns `exe` with the given argv (argv[0] is the display name only;
+   // actual process image comes from `exe`), redirecting stdout to a pipe
+   // this function drains and stderr to NUL (third-party plugin code prints
+   // whatever it wants there, and the scan has nowhere useful to put it).
+   // Mirrors PluginVST3.mm's posix_spawn + pipe + select loop with
+   // CreateProcessW + pipe + PeekNamedPipe.
+   bool RunProbeChild(const std::string& exe, const std::vector<std::string>& args,
+                       std::chrono::seconds timeout, std::string& outOutput, bool& outTimedOut,
+                       bool& outCleanExit)
+   {
+      outOutput.clear();
+      outTimedOut = false;
+      outCleanExit = false;
+
+      SECURITY_ATTRIBUTES saAttr = {};
+      saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+      saAttr.bInheritHandle = TRUE;
+      saAttr.lpSecurityDescriptor = nullptr;
+
+      HANDLE readPipe = nullptr;
+      HANDLE writePipe = nullptr;
+      if (!CreatePipe(&readPipe, &writePipe, &saAttr, 0))
+         return false;
+
+      // The read end must NOT be inherited by the child, or the child's copy
+      // of the write end never closes when the child exits (its own stdout
+      // handle keeps the pipe open) and the drain loop below would spin past
+      // its own deadline waiting for an EOF that never comes.
+      SetHandleInformation(readPipe, HANDLE_FLAG_INHERIT, 0);
+
+      HANDLE nulWrite = CreateFileW(L"NUL", GENERIC_WRITE, FILE_SHARE_WRITE | FILE_SHARE_READ,
+                                    &saAttr, OPEN_EXISTING, 0, nullptr);
+
+      STARTUPINFOW si = {};
+      si.cb = sizeof(si);
+      si.dwFlags |= STARTF_USESTDHANDLES;
+      si.hStdOutput = writePipe;
+      si.hStdError = nulWrite;
+      si.hStdInput = nullptr;
+
+      std::wstring cmdLine = L"\"" + WinCommon::Utf8ToWide(exe) + L"\"";
+      for (const std::string& a : args)
+         cmdLine += L" \"" + WinCommon::Utf8ToWide(a) + L"\"";
+      std::vector<wchar_t> cmdLineBuf(cmdLine.begin(), cmdLine.end());
+      cmdLineBuf.push_back(L'\0');
+
+      PROCESS_INFORMATION pi = {};
+      const BOOL ok = CreateProcessW(WinCommon::Utf8ToWide(exe).c_str(), cmdLineBuf.data(), nullptr, nullptr,
+                                     TRUE /* inherit handles */, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi);
+
+      // The parent's copies of the child-inherited handles must close now -
+      // otherwise the parent itself keeps the pipe/NUL handle alive and the
+      // drain loop's EOF-on-child-exit signal never arrives.
+      CloseHandle(writePipe);
+      if (nulWrite != nullptr && nulWrite != INVALID_HANDLE_VALUE)
+         CloseHandle(nulWrite);
+
+      if (!ok)
+      {
+         CloseHandle(readPipe);
+         return false;
+      }
+
+      const auto deadline = std::chrono::steady_clock::now() + timeout;
+      DrainResult drained = DrainChildStdout(readPipe, pi.hProcess, deadline);
+      CloseHandle(readPipe);
+      outOutput = std::move(drained.output);
+      outTimedOut = drained.timedOut;
+
+      if (outTimedOut)
+      {
+         VST3Trace("probe child timed out, terminating");
+         TerminateProcess(pi.hProcess, 1);
+         WaitForSingleObject(pi.hProcess, 2000);
+      }
+      else
+      {
+         WaitForSingleObject(pi.hProcess, 5000);
+      }
+
+      DWORD exitCode = 1;
+      GetExitCodeProcess(pi.hProcess, &exitCode);
+      outCleanExit = !outTimedOut && exitCode == 0;
+
+      CloseHandle(pi.hProcess);
+      CloseHandle(pi.hThread);
+      return true;
+   }
+
+   ProbeOutcome ProbeVST3BundleOutOfProcess(const std::string& bundlePath, std::vector<Platform::PluginDesc>& out)
+   {
+      std::string exe = Platform::ScannerExecutablePath();
+      bool isDedicatedScanner = true;
+      if (exe.empty() || !fsProbe::exists(exe))
+      {
+         exe = Platform::ExecutablePath();
+         isDedicatedScanner = false;
+      }
+      if (exe.empty())
+         return ProbeOutcome::Crashed;
+
+      std::vector<std::string> args;
+      if (!isDedicatedScanner)
+         args.push_back("--vst3-scan-bundle");
+      args.push_back(bundlePath);
+
+      std::string output;
+      bool timedOut = false;
+      bool cleanExit = false;
+      if (!RunProbeChild(exe, args, std::chrono::seconds(10), output, timedOut, cleanExit))
+         return ProbeOutcome::Crashed;
+
+      if (!cleanExit)
+      {
+         VST3Trace("bundle crashed or timed out during out-of-process probe: %s", bundlePath.c_str());
+         return ProbeOutcome::Crashed;
+      }
+
+      std::vector<Platform::PluginDesc> parsed = ParseProbeOutput(output);
+      if (parsed.empty())
+         return ProbeOutcome::CleanMiss;
+
+      for (Platform::PluginDesc& d : parsed)
+         out.push_back(std::move(d));
+      return ProbeOutcome::Success;
+   }
+
+   void ProbeVST3BundlesBatch(std::vector<std::string> bundlesToScan, std::vector<Platform::PluginDesc>& out)
+   {
+      const std::string exe = Platform::ScannerExecutablePath();
+      if (exe.empty() || !fsProbe::exists(exe))
+      {
+         // No dedicated scanner built (INFINITE_ENABLE_VST3 built the app but
+         // something went wrong with the scanner target) - fall back to
+         // probing one at a time via the self re-exec path, same as Mac's
+         // fallback.
+         for (const auto& path : bundlesToScan)
+         {
+            if (IsBlocklistedPath(path))
+            {
+               RecordScanFailure(path);
+               continue;
+            }
+            const ProbeOutcome outcome = ProbeVST3BundleOutOfProcess(path, out);
+            if (outcome == ProbeOutcome::Crashed)
+            {
+               RecordScanFailure(path);
+               std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+               AddToBlocklistLocked(path);
+            }
+            else if (outcome == ProbeOutcome::CleanMiss)
+            {
+               RecordScanFailure(path);
+            }
+         }
+         return;
+      }
+
+      while (!bundlesToScan.empty())
+      {
+         auto it = bundlesToScan.begin();
+         while (it != bundlesToScan.end())
+         {
+            if (IsBlocklistedPath(*it))
+            {
+               RecordScanFailure(*it);
+               it = bundlesToScan.erase(it);
+            }
+            else
+            {
+               ++it;
+            }
+         }
+         if (bundlesToScan.empty())
+            break;
+
+         std::vector<std::string> args;
+         args.push_back("--batch");
+         for (const auto& b : bundlesToScan)
+            args.push_back(b);
+
+         std::string output;
+         bool timedOut = false;
+         bool cleanExit = false;
+         if (!RunProbeChild(exe, args, std::chrono::seconds(60), output, timedOut, cleanExit))
+            break;
+
+         std::vector<Platform::PluginDesc> parsed = ParseProbeOutput(output);
+         for (Platform::PluginDesc& d : parsed)
+            out.push_back(std::move(d));
+
+         if (timedOut)
+         {
+            EnsureSentinelCheckedOnce();
+            break;
+         }
+         if (cleanExit)
+            break;
+
+         // Non-zero/killed exit with a partial or empty parse: the sentinel
+         // (written by whichever bundle the child was mid-probing) is what
+         // identifies and blocklists the offender on the next launch, same
+         // as the single-probe path.
+         EnsureSentinelCheckedOnce();
+      }
+   }
+}
+
+namespace Platform
+{
+   void SetVST3SearchFolders(const std::vector<std::string>& folders)
+   {
+      std::lock_guard<std::mutex> lock(gSearchFoldersMutex);
+      gExtraVST3SearchFolders = folders;
+   }
+
+   std::vector<std::string> VST3Blocklist()
+   {
+      std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+      LoadBlocklistLocked();
+      return gBlocklist;
+   }
+
+   void ClearVST3Blocklist()
+   {
+      std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+      LoadBlocklistLocked();
+      gBlocklist.clear();
+      SaveBlocklistLocked();
+   }
+
+   std::vector<std::string> VST3ScanFailures()
+   {
+      std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+      return gScanFailures;
+   }
+
+   // Recursive folder walk building the batch DescribeVST3Bundle probes.
+   // Unlike Mac (where only the directory-bundle form of ".vst3" exists), a
+   // plain single-file "Foo.vst3" DLL is also legal and common on Windows, so
+   // both forms are collected here - the directory form is not recursed into
+   // further once identified as a bundle.
+   void EnumerateVST3Plugins(const std::vector<std::string>& folders, std::vector<PluginDesc>& out)
+   {
+      EnsureSentinelCheckedOnce();
+      {
+         std::lock_guard<std::mutex> lock(gVST3SafetyMutex);
+         gScanFailures.clear();
+      }
+
+      std::vector<std::string> bundlesToScan;
+      for (const std::string& root : folders)
+      {
+         if (root.empty())
+            continue;
+         std::vector<fsProbe::path> dirStack;
+         dirStack.push_back(root);
+
+         while (!dirStack.empty())
+         {
+            fsProbe::path dir = std::move(dirStack.back());
+            dirStack.pop_back();
+
+            std::error_code ec;
+            fsProbe::directory_iterator it(dir, fsProbe::directory_options::skip_permission_denied, ec);
+            const fsProbe::directory_iterator end;
+            if (ec)
+               continue;
+
+            while (it != end)
+            {
+               const fsProbe::directory_entry entry = *it;
+               std::error_code entryEc;
+               if (entry.is_directory(entryEc) && !entryEc)
+               {
+                  if (entry.path().extension() == ".vst3")
+                     bundlesToScan.push_back(entry.path().string());
+                  else
+                     dirStack.push_back(entry.path());
+               }
+               else if (entry.is_regular_file(entryEc) && !entryEc && entry.path().extension() == ".vst3")
+               {
+                  bundlesToScan.push_back(entry.path().string());
+               }
+               it.increment(ec);
+               if (ec)
+                  break;
+            }
+         }
+      }
+
+      ProbeVST3BundlesBatch(std::move(bundlesToScan), out);
+   }
+
+   bool DescribeVST3Bundle(const std::string& bundlePath, std::vector<PluginDesc>& out)
+   {
+      EnsureSentinelCheckedOnce();
+      if (IsBlocklistedPath(bundlePath))
+      {
+         VST3Trace("refusing blocklisted bundle: %s", bundlePath.c_str());
+         return false;
+      }
+
+      // Sentinel window: everything between here and ClearSentinel() below
+      // runs arbitrary third-party code in-process (LoadLibraryExW, InitDll,
+      // the factory constructor). If this process doesn't survive that, the
+      // next launch finds the sentinel still pointing at this exact bundle
+      // and blocklists it instead of repeating the crash.
+      WriteSentinel(bundlePath);
+
+      Steinberg::IPluginFactory* factoryRaw = nullptr;
+      HMODULE module = LoadVST3Module(bundlePath, &factoryRaw);
+      if (module == nullptr || factoryRaw == nullptr)
+      {
+         ClearSentinel();
+         return false;
+      }
+
+      Steinberg::IPtr<Steinberg::IPluginFactory> factory(factoryRaw);
+      Steinberg::IPtr<Steinberg::IPluginFactory2> factory2;
+      factory->queryInterface(Steinberg::IPluginFactory2::iid, (void**)&factory2);
+
+      const Steinberg::int32 numClasses = factory->countClasses();
+      bool foundAny = false;
+
+      for (Steinberg::int32 i = 0; i < numClasses; i++)
+      {
+         Steinberg::PClassInfo classInfo = {};
+         Steinberg::PClassInfo2 classInfo2 = {};
+         std::string category;
+         std::string name;
+         std::string vendor;
+         std::string subCategories;
+         Steinberg::TUID classId = {};
+
+         if (factory2)
+         {
+            if (factory2->getClassInfo2(i, &classInfo2) == Steinberg::kResultOk)
+            {
+               category = classInfo2.category;
+               name = classInfo2.name;
+               vendor = classInfo2.vendor;
+               subCategories = classInfo2.subCategories;
+               std::memcpy(classId, classInfo2.cid, sizeof(Steinberg::TUID));
+            }
+         }
+         else
+         {
+            if (factory->getClassInfo(i, &classInfo) == Steinberg::kResultOk)
+            {
+               category = classInfo.category;
+               name = classInfo.name;
+               std::memcpy(classId, classInfo.cid, sizeof(Steinberg::TUID));
+            }
+         }
+
+         VST3Trace("  class[%d] category='%s' name='%s' uid=%s", (int)i, category.c_str(), name.c_str(),
+                   TUIDToHexString(classId).c_str());
+
+         if (category == kVstAudioEffectClass)
+         {
+            PluginDesc desc;
+            desc.format = "vst3";
+            desc.name = name;
+            desc.manufacturer = vendor;
+            desc.identifier = MakeVST3Identifier(classId);
+            desc.path = bundlePath;
+
+            std::string subCatLower = subCategories;
+            std::transform(subCatLower.begin(), subCatLower.end(), subCatLower.begin(), ::tolower);
+            desc.acceptsNotes = (subCatLower.find("instrument") != std::string::npos ||
+                                 subCatLower.find("synth") != std::string::npos);
+
+            CacheVST3BundlePath(desc.identifier, bundlePath);
+            out.push_back(std::move(desc));
+            foundAny = true;
+         }
+      }
+
+      UnloadVST3Module(module);
+      ClearSentinel();
+      return foundAny;
    }
 }
 
@@ -1241,6 +1944,63 @@ namespace
       FreeLibrary(module);
    }
 
+   // Arch-specific bundle subfolder name, matching the VST3 SDK's
+   // moduleinfo/bundle layout convention. Selected at compile time from the
+   // build target, not runtime - a given Infinite.exe only ever wants the
+   // subfolder matching its own architecture.
+#if defined(_M_ARM64EC)
+   constexpr const char* kVst3ArchFolder = "arm64ec-win";
+#elif defined(_M_ARM64)
+   constexpr const char* kVst3ArchFolder = "arm64-win";
+#else
+   constexpr const char* kVst3ArchFolder = "x86_64-win";
+#endif
+
+   // Bare-DLL fallback when the bundle doesn't use the conventional
+   // "<stem>.vst3" module name under Contents\<arch>-win\: scan that folder
+   // for any .vst3 file. Some plugins name the module differently from the
+   // bundle folder.
+   std::string FindVst3ModuleInArchFolder(const std::string& archFolderPath)
+   {
+      std::error_code ec;
+      if (!fs::is_directory(archFolderPath, ec))
+         return {};
+      for (const auto& entry : fs::directory_iterator(archFolderPath, ec))
+      {
+         if (ec)
+            break;
+         if (entry.is_regular_file(ec) && entry.path().extension() == ".vst3")
+            return entry.path().string();
+      }
+      return {};
+   }
+
+   // Fallback when the arch folder for this build target isn't present at
+   // all: scan every Contents\*-win\ folder for a .vst3 module. Covers
+   // plugins that only ship one architecture that doesn't match ours exactly
+   // (e.g. arm64ec-only builds run under x64 on ARM64 Windows via emulation).
+   std::string FindVst3ModuleInAnyArchFolder(const std::string& bundlePath)
+   {
+      std::error_code ec;
+      const std::string contentsPath = bundlePath + "\\Contents";
+      if (!fs::is_directory(contentsPath, ec))
+         return {};
+      for (const auto& archEntry : fs::directory_iterator(contentsPath, ec))
+      {
+         if (ec)
+            break;
+         if (!archEntry.is_directory(ec))
+            continue;
+         const std::string archName = archEntry.path().filename().string();
+         if (archName.size() < 4 || archName.compare(archName.size() - 4, 4, "-win") != 0)
+            continue;
+         std::string found = FindVst3ModuleInArchFolder(archEntry.path().string());
+         if (!found.empty())
+            return found;
+      }
+      return {};
+   }
+
    HMODULE LoadVST3Module(const std::string& bundlePath, Steinberg::IPluginFactory** outFactory)
    {
       if (outFactory != nullptr)
@@ -1252,14 +2012,32 @@ namespace
       std::string dllPath = bundlePath;
       if (fs::is_directory(bundlePath, ec))
       {
-         dllPath = bundlePath + "\\Contents\\x86_64-win\\" +
-                   fs::path(bundlePath).stem().string() + ".vst3";
+         const std::string archFolder = bundlePath + "\\Contents\\" + kVst3ArchFolder;
+         std::string conventional = archFolder + "\\" + fs::path(bundlePath).stem().string() + ".vst3";
+         if (fs::exists(conventional, ec))
+         {
+            dllPath = conventional;
+         }
+         else
+         {
+            std::string found = FindVst3ModuleInArchFolder(archFolder);
+            if (found.empty())
+               found = FindVst3ModuleInAnyArchFolder(bundlePath);
+            dllPath = found.empty() ? conventional : found;
+         }
       }
 
-      HMODULE module = LoadLibraryW(WinCommon::Utf8ToWide(dllPath).c_str());
+      // LOAD_WITH_ALTERED_SEARCH_PATH makes the module's own directory the
+      // first stop for its DLL imports, matching what CFBundleLoadExecutable
+      // gives us for free on Mac (a bundle's Frameworks/ dir is searched
+      // automatically). Plugins that ship helper DLLs next to their module
+      // fail to load without this. Requires an absolute path.
+      std::error_code absEc;
+      std::wstring dllPathW = WinCommon::Utf8ToWide(fs::absolute(dllPath, absEc).string());
+      HMODULE module = LoadLibraryExW(dllPathW.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
       if (module == nullptr)
       {
-         VST3Trace("LoadLibraryW failed: %s", dllPath.c_str());
+         VST3Trace("LoadLibraryExW failed: %s", dllPath.c_str());
          return nullptr;
       }
 
@@ -1441,11 +2219,39 @@ namespace Platform
                    bundlePath.c_str());
       }
 
-      // Step 3 (targeted rescan) on macOS also searches user-added folders via
-      // SetVST3SearchFolders; that plumbing isn't wired up on Windows yet
-      // (EnumerateVST3Plugins is still the no-op stub - see PluginHostWin.cpp),
-      // so a cache miss here just stays a miss rather than triggering a scan
-      // that can't find anything. Known gap, not a silent regression.
+      // Step 3: a targeted rescan, only if both of the above missed. Mirrors
+      // PluginVST3.mm's equivalent step - /Library/Audio/Plug-Ins/VST3 and
+      // ~/Library/Audio/Plug-Ins/VST3 become the two conventional Windows
+      // VST3 folders below.
+      if (bundlePath.empty())
+      {
+         std::vector<std::string> searchFolders;
+         wchar_t* commonProgramFiles = nullptr;
+         size_t cpfLen = 0;
+         if (_wdupenv_s(&commonProgramFiles, &cpfLen, L"COMMONPROGRAMFILES") == 0 && commonProgramFiles != nullptr)
+         {
+            searchFolders.push_back(WinCommon::WideToUtf8(std::wstring(commonProgramFiles) + L"\\VST3"));
+            free(commonProgramFiles);
+         }
+         wchar_t* localAppData = nullptr;
+         size_t ladLen = 0;
+         if (_wdupenv_s(&localAppData, &ladLen, L"LOCALAPPDATA") == 0 && localAppData != nullptr)
+         {
+            searchFolders.push_back(WinCommon::WideToUtf8(std::wstring(localAppData) + L"\\Programs\\Common\\VST3"));
+            free(localAppData);
+         }
+         for (const auto& extra : GetExtraVST3SearchFolders())
+            if (std::find(searchFolders.begin(), searchFolders.end(), extra) == searchFolders.end())
+               searchFolders.push_back(extra);
+         std::vector<PluginDesc> discovered;
+         VST3Trace("  cache miss; targeted rescan of %d folder(s)", (int)searchFolders.size());
+         for (const auto& f : searchFolders)
+            VST3Trace("    folder: %s", f.c_str());
+         EnumerateVST3Plugins(searchFolders, discovered);
+         bundlePath = GetCachedVST3BundlePath(desc.identifier);
+         VST3Trace("  rescan found %d plugin(s); cache lookup -> '%s'", (int)discovered.size(), bundlePath.c_str());
+      }
+
       if (bundlePath.empty())
       {
          std::string message = "VST3 not resolvable: " + desc.identifier;
@@ -2116,6 +2922,24 @@ namespace Platform
    // Editor Window
    // ------------------------------------------------------------------------
 
+   // Plugin editors commonly depend on OLE (drag-drop targets, common file
+   // dialogs invoked from a preset browser) on the thread that owns their
+   // HWND. Unlike the scoped CoInitializeEx pairs in PlatformWin.cpp's media
+   // paths, this must stay live for as long as any editor window might be
+   // open on this thread, which is the app's entire life once the first
+   // editor is opened - there is no natural single app-shutdown hook in this
+   // codebase to pair an OleUninitialize with, so it is left initialized and
+   // released by the OS at process exit, same as the window class registered
+   // by RegisterEditorWindowClassOnce() above.
+   void EnsureOleInitializedOnThisThreadOnce()
+   {
+      static thread_local bool initialized = false;
+      if (initialized)
+         return;
+      initialized = true;
+      OleInitialize(nullptr);
+   }
+
    bool PluginVST3OpenEditor(PluginHandle* h, std::string& outError)
    {
       if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller || h->state != PluginLoadState::Ready)
@@ -2124,6 +2948,8 @@ namespace Platform
          return false;
       }
       PluginVST3State* v = h->vst3;
+
+      EnsureOleInitializedOnThisThreadOnce();
 
       if (v->editorUnstable.load(std::memory_order_relaxed))
       {

--- a/src/platform/win/PluginVST3Win.cpp
+++ b/src/platform/win/PluginVST3Win.cpp
@@ -1,0 +1,2053 @@
+// Windows VST3 hosting - the portable ~75% of PluginVST3.mm (host glue
+// classes, create/init/process/parameter/state logic) ported essentially
+// unchanged, plus the genuinely Windows-specific pieces that are actually
+// needed for anything to instantiate at all (DLL loading, UTF-16 handling).
+//
+// Deliberately NOT ported in this phase (see the plan for the follow-up
+// sessions each of these becomes):
+//   - Editor window (HWND creation/embedding, kPlatformTypeHWND, resize).
+//     PluginVST3OpenEditor below stubs this out cleanly.
+//   - SEH crash guarding beyond state save/restore. Editor-related guarding
+//     has nothing to guard yet since there's no editor to open.
+//   - Out-of-process scanning, sentinel/blocklist persistence. Enumeration
+//     stays routed through PluginHostWin.cpp's existing no-op, so bundle
+//     resolution below only ever succeeds via desc.path or a same-session
+//     cache hit - never a fresh disk scan. This is a known, called-out gap,
+//     not a silent regression.
+
+#include "PluginVST3.h"
+
+#if INFINITE_ENABLE_VST3
+
+#include "PluginHandleInternalWin.h"
+#include "WinCommon.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "pluginterfaces/base/funknown.h"
+#include "pluginterfaces/base/ibstream.h"
+#include "pluginterfaces/base/ipluginbase.h"
+#include "pluginterfaces/base/smartpointer.h"
+#include "pluginterfaces/base/ustring.h"
+#include "pluginterfaces/gui/iplugview.h"
+#include "pluginterfaces/vst/ivstaudioprocessor.h"
+#include "pluginterfaces/vst/ivstcomponent.h"
+#include "pluginterfaces/vst/ivsteditcontroller.h"
+#include "pluginterfaces/vst/ivstevents.h"
+#include "pluginterfaces/vst/ivsthostapplication.h"
+#include "pluginterfaces/vst/ivstmessage.h"
+#include "pluginterfaces/vst/ivstparameterchanges.h"
+#include "pluginterfaces/vst/ivstprocesscontext.h"
+#include "pluginterfaces/vst/vstspeaker.h"
+#include "pluginterfaces/vst/vsttypes.h"
+
+namespace
+{
+   namespace fs = std::filesystem;
+
+   void VST3Trace(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+   void VST3Trace(const char* fmt, ...)
+   {
+      static const bool enabled = getenv("INFINITE_VST3TRACE") != nullptr;
+      if (!enabled)
+         return;
+      va_list args;
+      va_start(args, fmt);
+      std::fprintf(stderr, "[vst3] ");
+      std::vfprintf(stderr, fmt, args);
+      std::fprintf(stderr, "\n");
+      va_end(args);
+      std::fflush(stderr);
+   }
+
+   // ------------------------------------------------------------------------
+   // UID and string utilities - identical to PluginVST3.mm, zero OS calls.
+   // ------------------------------------------------------------------------
+
+   std::string TUIDToHexString(const Steinberg::TUID tuid)
+   {
+      char hex[33];
+      for (int i = 0; i < 16; i++)
+         std::snprintf(hex + i * 2, 3, "%02X", (unsigned char)tuid[i]);
+      hex[32] = '\0';
+      return std::string(hex);
+   }
+
+   bool HexStringToTUID(const std::string& hex, Steinberg::TUID outTUID)
+   {
+      if (hex.length() != 32)
+         return false;
+      for (int i = 0; i < 16; i++)
+      {
+         unsigned int byteVal = 0;
+         if (std::sscanf(hex.substr(i * 2, 2).c_str(), "%02x", &byteVal) != 1)
+            return false;
+         outTUID[i] = (char)(unsigned char)byteVal;
+      }
+      return true;
+   }
+
+   std::string MakeVST3Identifier(const Steinberg::TUID tuid)
+   {
+      return "vst3:" + TUIDToHexString(tuid);
+   }
+
+   bool ParseVST3Identifier(const std::string& id, Steinberg::TUID outTUID)
+   {
+      if (id.rfind("vst3:", 0) != 0)
+         return false;
+      return HexStringToTUID(id.substr(5), outTUID);
+   }
+
+   // Steinberg::Vst::TChar and wchar_t are both UTF-16 on Windows, so this is
+   // a straight width copy through WinCommon's UTF-8 <-> UTF-16 helpers
+   // rather than the NSString round-trip PluginVST3.mm uses.
+   static_assert(sizeof(Steinberg::Vst::TChar) == sizeof(wchar_t),
+                 "Steinberg::Vst::TChar must be UTF-16 to alias wchar_t on Windows");
+
+   std::string UTF16ToUTF8(const Steinberg::Vst::TChar* str)
+   {
+      if (str == nullptr)
+         return std::string();
+      return WinCommon::WideToUtf8(std::wstring(reinterpret_cast<const wchar_t*>(str)));
+   }
+
+   void UTF8ToUTF16(const std::string& utf8, Steinberg::Vst::TChar* outStr, int maxChars)
+   {
+      if (outStr == nullptr || maxChars <= 0)
+         return;
+      const std::wstring wide = WinCommon::Utf8ToWide(utf8);
+      const size_t len = std::min(wide.size(), (size_t)(maxChars - 1));
+      std::memcpy(outStr, wide.data(), len * sizeof(Steinberg::Vst::TChar));
+      outStr[len] = 0;
+   }
+
+   // ------------------------------------------------------------------------
+   // Minimal base64, needed only for state save/restore blobs (no existing
+   // helper elsewhere in the codebase to reuse).
+   // ------------------------------------------------------------------------
+
+   std::string Base64Encode(const std::vector<uint8_t>& data)
+   {
+      static const char kTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+      std::string out;
+      out.reserve(((data.size() + 2) / 3) * 4);
+      size_t i = 0;
+      while (i + 3 <= data.size())
+      {
+         const uint32_t n = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+         out.push_back(kTable[(n >> 18) & 0x3F]);
+         out.push_back(kTable[(n >> 12) & 0x3F]);
+         out.push_back(kTable[(n >> 6) & 0x3F]);
+         out.push_back(kTable[n & 0x3F]);
+         i += 3;
+      }
+      const size_t remaining = data.size() - i;
+      if (remaining == 1)
+      {
+         const uint32_t n = data[i] << 16;
+         out.push_back(kTable[(n >> 18) & 0x3F]);
+         out.push_back(kTable[(n >> 12) & 0x3F]);
+         out.push_back('=');
+         out.push_back('=');
+      }
+      else if (remaining == 2)
+      {
+         const uint32_t n = (data[i] << 16) | (data[i + 1] << 8);
+         out.push_back(kTable[(n >> 18) & 0x3F]);
+         out.push_back(kTable[(n >> 12) & 0x3F]);
+         out.push_back(kTable[(n >> 6) & 0x3F]);
+         out.push_back('=');
+      }
+      return out;
+   }
+
+   bool Base64Decode(const std::string& in, std::vector<uint8_t>& out)
+   {
+      auto decodeChar = [](char c) -> int
+      {
+         if (c >= 'A' && c <= 'Z') return c - 'A';
+         if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+         if (c >= '0' && c <= '9') return c - '0' + 52;
+         if (c == '+') return 62;
+         if (c == '/') return 63;
+         return -1;
+      };
+      out.clear();
+      int vals[4];
+      int count = 0;
+      for (char c : in)
+      {
+         if (c == '=' || c == '\r' || c == '\n')
+            continue;
+         const int v = decodeChar(c);
+         if (v < 0)
+            return false;
+         vals[count++] = v;
+         if (count == 4)
+         {
+            const uint32_t n = (vals[0] << 18) | (vals[1] << 12) | (vals[2] << 6) | vals[3];
+            out.push_back((uint8_t)((n >> 16) & 0xFF));
+            out.push_back((uint8_t)((n >> 8) & 0xFF));
+            out.push_back((uint8_t)(n & 0xFF));
+            count = 0;
+         }
+      }
+      if (count == 3)
+      {
+         const uint32_t n = (vals[0] << 18) | (vals[1] << 12) | (vals[2] << 6);
+         out.push_back((uint8_t)((n >> 16) & 0xFF));
+         out.push_back((uint8_t)((n >> 8) & 0xFF));
+      }
+      else if (count == 2)
+      {
+         const uint32_t n = (vals[0] << 18) | (vals[1] << 12);
+         out.push_back((uint8_t)((n >> 16) & 0xFF));
+      }
+      else if (count == 1)
+      {
+         return false; // malformed
+      }
+      return true;
+   }
+}
+
+namespace Platform
+{
+   // Identifier -> bundle path cache, exactly as PluginVST3.mm's. Real disk
+   // scanning isn't ported yet (see file header), so this only ever gets
+   // populated from a desc.path that resolved successfully - still useful
+   // for re-resolving the same plugin later in the same process run.
+   static std::mutex gBundleMapMutex;
+   static std::unordered_map<std::string, std::string> gVST3BundleMap;
+
+   void CacheVST3BundlePath(const std::string& identifier, const std::string& bundlePath)
+   {
+      std::lock_guard<std::mutex> lock(gBundleMapMutex);
+      gVST3BundleMap[identifier] = bundlePath;
+   }
+
+   std::string GetCachedVST3BundlePath(const std::string& identifier)
+   {
+      std::lock_guard<std::mutex> lock(gBundleMapMutex);
+      auto it = gVST3BundleMap.find(identifier);
+      return it != gVST3BundleMap.end() ? it->second : std::string();
+   }
+}
+
+namespace
+{
+   // ------------------------------------------------------------------------
+   // MemoryStream for IBStream state save/restore - identical to PluginVST3.mm.
+   // ------------------------------------------------------------------------
+
+   class MemoryStream : public Steinberg::IBStream
+   {
+   public:
+      MemoryStream() = default;
+      explicit MemoryStream(const void* data, size_t size)
+      {
+         if (data != nullptr && size > 0)
+            mBuffer.assign((const uint8_t*)data, (const uint8_t*)data + size);
+      }
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::IBStream::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::tresult PLUGIN_API read(void* buffer, Steinberg::int32 numBytes, Steinberg::int32* numBytesRead) override
+      {
+         if (buffer == nullptr || numBytes < 0)
+            return Steinberg::kInvalidArgument;
+         const size_t available = (mPos < mBuffer.size()) ? (mBuffer.size() - mPos) : 0;
+         const size_t toRead = std::min((size_t)numBytes, available);
+         if (toRead > 0)
+         {
+            std::memcpy(buffer, mBuffer.data() + mPos, toRead);
+            mPos += toRead;
+         }
+         if (numBytesRead != nullptr)
+            *numBytesRead = (Steinberg::int32)toRead;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API write(void* buffer, Steinberg::int32 numBytes, Steinberg::int32* numBytesWritten) override
+      {
+         if (buffer == nullptr || numBytes < 0)
+            return Steinberg::kInvalidArgument;
+         if (mPos + (size_t)numBytes > mBuffer.size())
+            mBuffer.resize(mPos + (size_t)numBytes);
+         std::memcpy(mBuffer.data() + mPos, buffer, (size_t)numBytes);
+         mPos += (size_t)numBytes;
+         if (numBytesWritten != nullptr)
+            *numBytesWritten = numBytes;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API seek(Steinberg::int64 offset, Steinberg::int32 mode, Steinberg::int64* result) override
+      {
+         Steinberg::int64 newPos = (Steinberg::int64)mPos;
+         if (mode == Steinberg::IBStream::kIBSeekSet)
+            newPos = offset;
+         else if (mode == Steinberg::IBStream::kIBSeekCur)
+            newPos += offset;
+         else if (mode == Steinberg::IBStream::kIBSeekEnd)
+            newPos = (Steinberg::int64)mBuffer.size() + offset;
+
+         if (newPos < 0)
+            return Steinberg::kInvalidArgument;
+         mPos = (size_t)newPos;
+         if (result != nullptr)
+            *result = (Steinberg::int64)mPos;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API tell(Steinberg::int64* result) override
+      {
+         if (result != nullptr)
+            *result = (Steinberg::int64)mPos;
+         return Steinberg::kResultOk;
+      }
+
+      const std::vector<uint8_t>& getBuffer() const { return mBuffer; }
+      size_t getSize() const { return mBuffer.size(); }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      std::vector<uint8_t> mBuffer;
+      size_t mPos = 0;
+   };
+
+   // ------------------------------------------------------------------------
+   // Host Application Context - identical to PluginVST3.mm.
+   // ------------------------------------------------------------------------
+
+   class HostApplication : public Steinberg::Vst::IHostApplication
+   {
+   public:
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IHostApplication::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::tresult PLUGIN_API getName(Steinberg::Vst::String128 name) override
+      {
+         UTF8ToUTF16("Infinite", name, 128);
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API createInstance(Steinberg::TUID cid, Steinberg::TUID _iid, void** obj) override;
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+   };
+
+   class HostAttributeList : public Steinberg::Vst::IAttributeList
+   {
+   public:
+      using AttrID = Steinberg::Vst::IAttributeList::AttrID;
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IAttributeList::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::tresult PLUGIN_API setInt(AttrID aid, Steinberg::int64 value) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         Attribute a;
+         a.type = Attribute::Type::kInt;
+         a.intValue = value;
+         mAttrs[aid] = std::move(a);
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API getInt(AttrID aid, Steinberg::int64& value) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         auto it = mAttrs.find(aid);
+         if (it == mAttrs.end() || it->second.type != Attribute::Type::kInt)
+            return Steinberg::kResultFalse;
+         value = it->second.intValue;
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API setFloat(AttrID aid, double value) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         Attribute a;
+         a.type = Attribute::Type::kFloat;
+         a.floatValue = value;
+         mAttrs[aid] = std::move(a);
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API getFloat(AttrID aid, double& value) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         auto it = mAttrs.find(aid);
+         if (it == mAttrs.end() || it->second.type != Attribute::Type::kFloat)
+            return Steinberg::kResultFalse;
+         value = it->second.floatValue;
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API setString(AttrID aid, const Steinberg::Vst::TChar* string) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         Attribute a;
+         a.type = Attribute::Type::kString;
+         if (string != nullptr)
+         {
+            size_t len = 0;
+            while (string[len] != 0)
+               len++;
+            a.stringValue.assign(string, string + len);
+         }
+         a.stringValue.push_back(0);
+         mAttrs[aid] = std::move(a);
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API getString(AttrID aid, Steinberg::Vst::TChar* string, Steinberg::uint32 sizeInBytes) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         auto it = mAttrs.find(aid);
+         if (it == mAttrs.end() || it->second.type != Attribute::Type::kString)
+            return Steinberg::kResultFalse;
+         const size_t haveBytes = it->second.stringValue.size() * sizeof(Steinberg::Vst::TChar);
+         const size_t copyBytes = std::min<size_t>(haveBytes, sizeInBytes);
+         std::memcpy(string, it->second.stringValue.data(), copyBytes);
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API setBinary(AttrID aid, const void* data, Steinberg::uint32 sizeInBytes) override
+      {
+         if (!aid)
+            return Steinberg::kInvalidArgument;
+         Attribute a;
+         a.type = Attribute::Type::kBinary;
+         const uint8_t* p = static_cast<const uint8_t*>(data);
+         a.binaryValue.assign(p, p + sizeInBytes);
+         mAttrs[aid] = std::move(a);
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API getBinary(AttrID aid, const void*& data, Steinberg::uint32& sizeInBytes) override
+      {
+         if (!aid)
+         {
+            sizeInBytes = 0;
+            return Steinberg::kInvalidArgument;
+         }
+         auto it = mAttrs.find(aid);
+         if (it == mAttrs.end() || it->second.type != Attribute::Type::kBinary)
+         {
+            sizeInBytes = 0;
+            return Steinberg::kResultFalse;
+         }
+         data = it->second.binaryValue.data();
+         sizeInBytes = (Steinberg::uint32)it->second.binaryValue.size();
+         return Steinberg::kResultTrue;
+      }
+
+   private:
+      struct Attribute
+      {
+         enum class Type { kInt, kFloat, kString, kBinary } type = Type::kInt;
+         Steinberg::int64 intValue = 0;
+         double floatValue = 0.0;
+         std::vector<Steinberg::Vst::TChar> stringValue;
+         std::vector<uint8_t> binaryValue;
+      };
+
+      std::atomic<uint32_t> mRefCount { 1 };
+      std::map<std::string, Attribute> mAttrs;
+   };
+
+   class HostMessage : public Steinberg::Vst::IMessage
+   {
+   public:
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IMessage::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::FIDString PLUGIN_API getMessageID() override
+      {
+         return mMessageId.empty() ? nullptr : mMessageId.c_str();
+      }
+
+      void PLUGIN_API setMessageID(Steinberg::FIDString mid) override
+      {
+         mMessageId = (mid != nullptr) ? mid : "";
+      }
+
+      Steinberg::Vst::IAttributeList* PLUGIN_API getAttributes() override
+      {
+         if (!mAttributes)
+            mAttributes = Steinberg::owned(new HostAttributeList());
+         return mAttributes.get();
+      }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      std::string mMessageId;
+      Steinberg::IPtr<Steinberg::Vst::IAttributeList> mAttributes;
+   };
+
+   Steinberg::tresult PLUGIN_API HostApplication::createInstance(Steinberg::TUID cid, Steinberg::TUID _iid, void** obj)
+   {
+      if (Steinberg::FUnknownPrivate::iidEqual(cid, Steinberg::Vst::IMessage::iid) &&
+          Steinberg::FUnknownPrivate::iidEqual(_iid, Steinberg::Vst::IMessage::iid))
+      {
+         *obj = new HostMessage();
+         return Steinberg::kResultTrue;
+      }
+      if (Steinberg::FUnknownPrivate::iidEqual(cid, Steinberg::Vst::IAttributeList::iid) &&
+          Steinberg::FUnknownPrivate::iidEqual(_iid, Steinberg::Vst::IAttributeList::iid))
+      {
+         *obj = new HostAttributeList();
+         return Steinberg::kResultTrue;
+      }
+      *obj = nullptr;
+      return Steinberg::kNoInterface;
+   }
+
+   Steinberg::Vst::IHostApplication* SharedHostApplication()
+   {
+      static HostApplication* instance = new HostApplication();
+      return instance;
+   }
+
+   // ------------------------------------------------------------------------
+   // Real-time safe event list / parameter changes - identical to PluginVST3.mm.
+   // ------------------------------------------------------------------------
+
+   class HostEventList : public Steinberg::Vst::IEventList
+   {
+   public:
+      static constexpr int kMaxEvents = 64;
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IEventList::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::int32 PLUGIN_API getEventCount() override
+      {
+         return mCount.load(std::memory_order_relaxed);
+      }
+
+      Steinberg::tresult PLUGIN_API getEvent(Steinberg::int32 index, Steinberg::Vst::Event& e) override
+      {
+         const int count = mCount.load(std::memory_order_relaxed);
+         if (index < 0 || index >= count)
+            return Steinberg::kInvalidArgument;
+         e = mEvents[index];
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API addEvent(Steinberg::Vst::Event& e) override
+      {
+         int count = mCount.load(std::memory_order_relaxed);
+         if (count >= kMaxEvents)
+            return Steinberg::kResultFalse;
+         mEvents[count] = e;
+         mCount.store(count + 1, std::memory_order_relaxed);
+         return Steinberg::kResultOk;
+      }
+
+      void clear() { mCount.store(0, std::memory_order_relaxed); }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      std::atomic<int> mCount { 0 };
+      Steinberg::Vst::Event mEvents[kMaxEvents] = {};
+   };
+
+   class HostParamValueQueue : public Steinberg::Vst::IParamValueQueue
+   {
+   public:
+      static constexpr int kMaxPoints = 8;
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IParamValueQueue::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::Vst::ParamID PLUGIN_API getParameterId() override { return mParamId; }
+
+      Steinberg::int32 PLUGIN_API getPointCount() override
+      {
+         return mPointCount.load(std::memory_order_relaxed);
+      }
+
+      Steinberg::tresult PLUGIN_API getPoint(Steinberg::int32 index, Steinberg::int32& sampleOffset,
+                                             Steinberg::Vst::ParamValue& value) override
+      {
+         const int count = mPointCount.load(std::memory_order_relaxed);
+         if (index < 0 || index >= count)
+            return Steinberg::kInvalidArgument;
+         sampleOffset = mOffsets[index];
+         value = mValues[index];
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API addPoint(Steinberg::int32 sampleOffset, Steinberg::Vst::ParamValue value,
+                                             Steinberg::int32& index) override
+      {
+         int count = mPointCount.load(std::memory_order_relaxed);
+         if (count >= kMaxPoints)
+         {
+            index = count - 1;
+            mOffsets[index] = sampleOffset;
+            mValues[index] = value;
+            return Steinberg::kResultOk;
+         }
+         index = count;
+         mOffsets[index] = sampleOffset;
+         mValues[index] = value;
+         mPointCount.store(count + 1, std::memory_order_relaxed);
+         return Steinberg::kResultOk;
+      }
+
+      void init(Steinberg::Vst::ParamID id)
+      {
+         mParamId = id;
+         mPointCount.store(0, std::memory_order_relaxed);
+      }
+
+      void clear() { mPointCount.store(0, std::memory_order_relaxed); }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      Steinberg::Vst::ParamID mParamId = 0;
+      std::atomic<int> mPointCount { 0 };
+      Steinberg::int32 mOffsets[kMaxPoints] = {};
+      Steinberg::Vst::ParamValue mValues[kMaxPoints] = {};
+   };
+
+   class HostParameterChanges : public Steinberg::Vst::IParameterChanges
+   {
+   public:
+      static constexpr int kMaxQueues = 32;
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IParameterChanges::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::int32 PLUGIN_API getParameterCount() override
+      {
+         return mQueueCount.load(std::memory_order_relaxed);
+      }
+
+      Steinberg::Vst::IParamValueQueue* PLUGIN_API getParameterData(Steinberg::int32 index) override
+      {
+         const int count = mQueueCount.load(std::memory_order_relaxed);
+         if (index < 0 || index >= count)
+            return nullptr;
+         return &mQueues[index];
+      }
+
+      Steinberg::Vst::IParamValueQueue* PLUGIN_API addParameterData(const Steinberg::Vst::ParamID& id,
+                                                                    Steinberg::int32& index) override
+      {
+         int count = mQueueCount.load(std::memory_order_relaxed);
+         for (int i = 0; i < count; i++)
+         {
+            if (mQueues[i].getParameterId() == id)
+            {
+               index = i;
+               return &mQueues[i];
+            }
+         }
+         if (count >= kMaxQueues)
+         {
+            index = -1;
+            return nullptr;
+         }
+         index = count;
+         mQueues[index].init(id);
+         mQueueCount.store(count + 1, std::memory_order_relaxed);
+         return &mQueues[index];
+      }
+
+      void clear() { mQueueCount.store(0, std::memory_order_relaxed); }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      std::atomic<int> mQueueCount { 0 };
+      HostParamValueQueue mQueues[kMaxQueues];
+   };
+
+   // ------------------------------------------------------------------------
+   // Host Component Handler - identical to PluginVST3.mm.
+   // ------------------------------------------------------------------------
+
+   class HostComponentHandler : public Steinberg::Vst::IComponentHandler,
+                                public Steinberg::Vst::IComponentHandler2,
+                                public Steinberg::Vst::IComponentHandlerBusActivation
+   {
+   public:
+      explicit HostComponentHandler(Platform::PluginHandle* handle) : mHandle(handle) {}
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IComponentHandler::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = static_cast<Steinberg::Vst::IComponentHandler*>(this);
+            return Steinberg::kResultOk;
+         }
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IComponentHandler2::iid))
+         {
+            addRef();
+            *obj = static_cast<Steinberg::Vst::IComponentHandler2*>(this);
+            return Steinberg::kResultOk;
+         }
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IComponentHandlerBusActivation::iid))
+         {
+            addRef();
+            *obj = static_cast<Steinberg::Vst::IComponentHandlerBusActivation*>(this);
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::tresult PLUGIN_API beginEdit(Steinberg::Vst::ParamID id) override
+      {
+         RecordTouch(id);
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API performEdit(Steinberg::Vst::ParamID id,
+                                                Steinberg::Vst::ParamValue valueNormalized) override
+      {
+         (void)valueNormalized;
+         RecordTouch(id);
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API endEdit(Steinberg::Vst::ParamID id) override
+      {
+         (void)id;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API restartComponent(Steinberg::int32 flags) override
+      {
+         (void)flags;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API setDirty(Steinberg::TBool state) override
+      {
+         (void)state;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API requestOpenEditor(Steinberg::FIDString name) override
+      {
+         (void)name;
+         return Steinberg::kResultOk;
+      }
+
+      Steinberg::tresult PLUGIN_API startGroupEdit() override { return Steinberg::kResultOk; }
+      Steinberg::tresult PLUGIN_API finishGroupEdit() override { return Steinberg::kResultOk; }
+
+      Steinberg::tresult PLUGIN_API requestBusActivation(Steinberg::Vst::MediaType type,
+                                                         Steinberg::Vst::BusDirection dir,
+                                                         Steinberg::int32 index,
+                                                         Steinberg::TBool state) override
+      {
+         (void)type;
+         (void)dir;
+         (void)index;
+         (void)state;
+         return Steinberg::kResultOk;
+      }
+
+      void detach() { mHandle = nullptr; }
+
+   private:
+      void RecordTouch(Steinberg::Vst::ParamID id);
+
+      std::atomic<uint32_t> mRefCount { 1 };
+      Platform::PluginHandle* mHandle = nullptr;
+   };
+
+   // ------------------------------------------------------------------------
+   // Host-side connection proxy.
+   //
+   // On macOS this marshals notify() onto the main thread via
+   // dispatch_async(dispatch_get_main_queue()). Windows has no equivalent
+   // main-thread-post primitive yet (that only becomes necessary once the
+   // editor phase lands and a plugin's GUI can legitimately push state from
+   // the audio thread). For this foundation phase notify() is called
+   // synchronously on whichever thread sent it - a documented simplification,
+   // not an oversight - to be replaced with a real main-thread queue in the
+   // editor-window follow-up session.
+   // ------------------------------------------------------------------------
+   class HostConnectionProxy : public Steinberg::Vst::IConnectionPoint
+   {
+   public:
+      explicit HostConnectionProxy(Steinberg::Vst::IConnectionPoint* srcPoint) : mSrc(srcPoint) {}
+
+      Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID iid, void** obj) override
+      {
+         if (Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::IConnectionPoint::iid) ||
+             Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::FUnknown::iid))
+         {
+            addRef();
+            *obj = this;
+            return Steinberg::kResultOk;
+         }
+         *obj = nullptr;
+         return Steinberg::kNoInterface;
+      }
+
+      Steinberg::uint32 PLUGIN_API addRef() override { return ++mRefCount; }
+      Steinberg::uint32 PLUGIN_API release() override
+      {
+         if (--mRefCount == 0)
+         {
+            delete this;
+            return 0;
+         }
+         return mRefCount;
+      }
+
+      Steinberg::tresult PLUGIN_API connect(Steinberg::Vst::IConnectionPoint* other) override
+      {
+         if (other == nullptr)
+            return Steinberg::kInvalidArgument;
+         if (mDst || !mSrc)
+            return Steinberg::kResultFalse;
+         mDst = other;
+         Steinberg::tresult res = mSrc->connect(this);
+         if (res != Steinberg::kResultTrue)
+            mDst = nullptr;
+         return res;
+      }
+
+      Steinberg::tresult PLUGIN_API disconnect(Steinberg::Vst::IConnectionPoint* other) override
+      {
+         if (other == nullptr)
+            return Steinberg::kInvalidArgument;
+         if (other != mDst.get())
+            return Steinberg::kInvalidArgument;
+         if (mSrc)
+            mSrc->disconnect(this);
+         mDst = nullptr;
+         return Steinberg::kResultTrue;
+      }
+
+      Steinberg::tresult PLUGIN_API notify(Steinberg::Vst::IMessage* message) override
+      {
+         if (!mDst || message == nullptr)
+            return Steinberg::kResultFalse;
+         mDst->notify(message);
+         return Steinberg::kResultTrue;
+      }
+
+      void DisconnectFromSource()
+      {
+         if (mDst)
+            disconnect(mDst.get());
+      }
+
+   private:
+      std::atomic<uint32_t> mRefCount { 1 };
+      Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mSrc;
+      Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mDst;
+   };
+}
+
+namespace Platform
+{
+   // ------------------------------------------------------------------------
+   // Internal VST3 state - Windows equivalent of PluginVST3.mm's
+   // PluginVST3State. Same shape minus the editor-window/NSWindow fields
+   // (editor hosting is stubbed this phase) and minus the sentinel/blocklist
+   // fields (scanning is deferred).
+   // ------------------------------------------------------------------------
+   struct PluginVST3State
+   {
+      HMODULE module = nullptr;
+      Steinberg::IPtr<Steinberg::IPluginFactory> factory;
+      Steinberg::IPtr<Steinberg::Vst::IComponent> component;
+      Steinberg::IPtr<Steinberg::Vst::IEditController> controller;
+      Steinberg::IPtr<Steinberg::Vst::IAudioProcessor> processor;
+      Steinberg::IPtr<Steinberg::IPlugView> plugView;
+      Steinberg::IPtr<HostComponentHandler> componentHandler;
+
+      Steinberg::IPtr<HostConnectionProxy> compToCtrlProxy;
+      Steinberg::IPtr<HostConnectionProxy> ctrlToCompProxy;
+
+      // On macOS this is set from a background dispatch_async block, polled
+      // by PluginVST3Poll. Here PluginVST3Create resolves and instantiates
+      // synchronously before returning (see PluginVST3Create below for why),
+      // so this is always true by the time the handle is returned - kept
+      // anyway so PluginVST3Poll's logic below matches PluginVST3.mm's
+      // unchanged.
+      std::mutex arrivalMutex;
+      std::atomic<bool> arrived { false };
+      std::string arrivedError;
+
+      double sampleRate = 0.0;
+      int maxBlockFrames = 0;
+      int pluginInChannels = 0;
+      int pluginOutChannels = 0;
+      bool active = false;
+      bool processing = false;
+
+      Steinberg::Vst::ProcessData processData;
+      Steinberg::Vst::AudioBusBuffers inputBusBuffers[1] = {};
+      Steinberg::Vst::AudioBusBuffers outputBusBuffers[1] = {};
+      float* inChannelPtrs[8] = {};
+      float* outChannelPtrs[8] = {};
+      std::vector<float> inScratch;
+      std::vector<float> outScratch;
+      std::vector<float> zeroScratch;
+
+      HostEventList inputEvents;
+      HostEventList outputEvents;
+      HostParameterChanges inputParamChanges;
+      HostParameterChanges outputParamChanges;
+      Steinberg::Vst::ProcessContext processContext;
+      Steinberg::int64 sampleTime = 0;
+
+      std::atomic<bool> learning { false };
+      std::atomic<unsigned long long> learnedAddress { 0 };
+      std::atomic<bool> learnedValid { false };
+
+      std::atomic<bool> inRender { false };
+
+      // Set once a crash guard catches this instance faulting inside
+      // getState/setState. See RunPluginCallGuarded below.
+      std::atomic<bool> stateCallsUnstable { false };
+   };
+}
+
+namespace
+{
+   void HostComponentHandler::RecordTouch(Steinberg::Vst::ParamID id)
+   {
+      if (mHandle == nullptr || mHandle->vst3 == nullptr)
+         return;
+      if (!mHandle->vst3->learning.load(std::memory_order_relaxed))
+         return;
+      mHandle->vst3->learnedAddress.store((unsigned long long)id, std::memory_order_relaxed);
+      mHandle->vst3->learnedValid.store(true, std::memory_order_release);
+   }
+
+   using GetPluginFactoryProc = Steinberg::IPluginFactory* (*)();
+   using InitDllProc = bool (*)();
+   using ExitDllProc = bool (*)();
+
+   // Mechanical swap for CFBundleLoadExecutable/CFBundleGetFunctionPointerForName:
+   // a VST3 module on Windows is a DLL, either bare (older single-file .vst3)
+   // or inside the standard bundle-folder layout
+   // "<name>.vst3/Contents/x86_64-win/<name>.vst3". InitDll/ExitDll are the
+   // exact Windows-side equivalents of bundleEntry/bundleExit - optional, but
+   // skipped for the same reason it isn't optional on Mac: plugins that load
+   // resources relative to their own module fail at instantiation without it.
+   void UnloadVST3Module(HMODULE module)
+   {
+      if (module == nullptr)
+         return;
+      if (ExitDllProc exitDll = (ExitDllProc)GetProcAddress(module, "ExitDll"))
+         exitDll();
+      FreeLibrary(module);
+   }
+
+   HMODULE LoadVST3Module(const std::string& bundlePath, Steinberg::IPluginFactory** outFactory)
+   {
+      if (outFactory != nullptr)
+         *outFactory = nullptr;
+      if (bundlePath.empty())
+         return nullptr;
+
+      std::error_code ec;
+      std::string dllPath = bundlePath;
+      if (fs::is_directory(bundlePath, ec))
+      {
+         dllPath = bundlePath + "\\Contents\\x86_64-win\\" +
+                   fs::path(bundlePath).stem().string() + ".vst3";
+      }
+
+      HMODULE module = LoadLibraryW(WinCommon::Utf8ToWide(dllPath).c_str());
+      if (module == nullptr)
+      {
+         VST3Trace("LoadLibraryW failed: %s", dllPath.c_str());
+         return nullptr;
+      }
+
+      if (InitDllProc initDll = (InitDllProc)GetProcAddress(module, "InitDll"))
+      {
+         if (!initDll())
+         {
+            VST3Trace("InitDll failed: %s", dllPath.c_str());
+            FreeLibrary(module);
+            return nullptr;
+         }
+      }
+
+      GetPluginFactoryProc getFactory = (GetPluginFactoryProc)GetProcAddress(module, "GetPluginFactory");
+      if (getFactory == nullptr)
+      {
+         VST3Trace("no GetPluginFactory export: %s", dllPath.c_str());
+         UnloadVST3Module(module);
+         return nullptr;
+      }
+
+      Steinberg::IPluginFactory* factory = getFactory();
+      if (factory == nullptr)
+      {
+         VST3Trace("GetPluginFactory returned null: %s", dllPath.c_str());
+         UnloadVST3Module(module);
+         return nullptr;
+      }
+
+      if (outFactory != nullptr)
+         *outFactory = factory;
+      return module;
+   }
+}
+
+namespace Platform
+{
+   PluginHandle* PluginVST3Create(const PluginDesc& desc, double sampleRate, int maxBlockFrames)
+   {
+      PluginHandle* h = new PluginHandle();
+      h->desc = desc;
+      h->state = PluginLoadState::Pending;
+      h->sampleRate = sampleRate;
+      h->maxBlockFrames = maxBlockFrames > 0 ? maxBlockFrames : 512;
+
+      PluginVST3State* v = new PluginVST3State();
+      v->sampleRate = h->sampleRate;
+      v->maxBlockFrames = h->maxBlockFrames;
+      h->vst3 = v;
+
+      struct TUIDHolder { Steinberg::TUID data; };
+      TUIDHolder cidHolder {};
+      if (!ParseVST3Identifier(desc.identifier, cidHolder.data))
+      {
+         h->state = PluginLoadState::Failed;
+         h->loadError = "invalid VST3 identifier: " + desc.identifier;
+         v->arrived.store(true, std::memory_order_release);
+         return h;
+      }
+
+      // macOS defers this block to the main run loop (see PluginVST3.mm) because
+      // several real plugins create AppKit objects synchronously inside their
+      // own factory/createInstance and abort if that happens off the main
+      // thread. Windows has no equivalent constraint here and no established
+      // "post to main thread, non-blocking" primitive yet, so this phase runs
+      // the whole resolve-and-instantiate sequence synchronously instead -
+      // PluginCreate is already only ever called from the UI thread that owns
+      // the topology, so this briefly blocks that thread exactly the way the
+      // Mac path does once its deferred block actually runs.
+      VST3Trace("resolve begin: name='%s' id='%s' path='%s'", desc.name.c_str(), desc.identifier.c_str(),
+                desc.path.c_str());
+
+      std::string bundlePath;
+      std::string lastKnownPath;
+      bool wasIndexed = false;
+
+      if (!desc.path.empty() && fs::exists(desc.path))
+      {
+         bundlePath = desc.path;
+         CacheVST3BundlePath(desc.identifier, bundlePath);
+         VST3Trace("  resolved from desc.path");
+      }
+      else
+      {
+         if (!desc.path.empty())
+         {
+            wasIndexed = true;
+            lastKnownPath = desc.path;
+         }
+         bundlePath = GetCachedVST3BundlePath(desc.identifier);
+         if (!bundlePath.empty())
+         {
+            wasIndexed = true;
+            lastKnownPath = bundlePath;
+         }
+         VST3Trace("  desc.path unusable (empty=%d); cache lookup -> '%s'", (int)desc.path.empty(),
+                   bundlePath.c_str());
+      }
+
+      // Step 3 (targeted rescan) on macOS also searches user-added folders via
+      // SetVST3SearchFolders; that plumbing isn't wired up on Windows yet
+      // (EnumerateVST3Plugins is still the no-op stub - see PluginHostWin.cpp),
+      // so a cache miss here just stays a miss rather than triggering a scan
+      // that can't find anything. Known gap, not a silent regression.
+      if (bundlePath.empty())
+      {
+         std::string message = "VST3 not resolvable: " + desc.identifier;
+         if (wasIndexed)
+            message += " (indexed at " + lastKnownPath + ", which no longer exists - rescan plugins)";
+         else
+            message += " (not found in the plugin index - rescan plugins)";
+         {
+            std::lock_guard<std::mutex> lock(v->arrivalMutex);
+            v->arrivedError = message;
+         }
+         VST3Trace("  %s", message.c_str());
+         v->arrived.store(true, std::memory_order_release);
+         return h;
+      }
+
+      Steinberg::IPluginFactory* factoryRaw = nullptr;
+      HMODULE module = LoadVST3Module(bundlePath, &factoryRaw);
+      if (module == nullptr || factoryRaw == nullptr)
+      {
+         {
+            std::lock_guard<std::mutex> lock(v->arrivalMutex);
+            v->arrivedError = "failed to load VST3 module";
+         }
+         v->arrived.store(true, std::memory_order_release);
+         return h;
+      }
+
+      v->module = module;
+      v->factory = factoryRaw;
+
+      {
+         Steinberg::IPtr<Steinberg::IPluginFactory3> factory3;
+         if (v->factory->queryInterface(Steinberg::IPluginFactory3::iid, (void**)&factory3) ==
+                Steinberg::kResultOk &&
+             factory3)
+            factory3->setHostContext((Steinberg::FUnknown*)SharedHostApplication());
+      }
+
+      Steinberg::Vst::IComponent* compRaw = nullptr;
+      if (v->factory->createInstance(cidHolder.data, Steinberg::Vst::IComponent::iid, (void**)&compRaw) != Steinberg::kResultOk ||
+          compRaw == nullptr)
+      {
+         {
+            std::lock_guard<std::mutex> lock(v->arrivalMutex);
+            v->arrivedError = "failed to create VST3 component instance";
+         }
+         v->arrived.store(true, std::memory_order_release);
+         return h;
+      }
+      v->component = Steinberg::owned(compRaw);
+
+      Steinberg::Vst::IEditController* ctrlRaw = nullptr;
+      if (compRaw->queryInterface(Steinberg::Vst::IEditController::iid, (void**)&ctrlRaw) == Steinberg::kResultOk &&
+          ctrlRaw != nullptr)
+      {
+         v->controller = Steinberg::owned(ctrlRaw);
+      }
+      else
+      {
+         Steinberg::TUID controllerCID = {};
+         if (compRaw->getControllerClassId(controllerCID) == Steinberg::kResultTrue)
+         {
+            if (v->factory->createInstance(controllerCID, Steinberg::Vst::IEditController::iid, (void**)&ctrlRaw) == Steinberg::kResultOk &&
+                ctrlRaw != nullptr)
+               v->controller = Steinberg::owned(ctrlRaw);
+         }
+      }
+
+      Steinberg::Vst::IAudioProcessor* procRaw = nullptr;
+      if (compRaw->queryInterface(Steinberg::Vst::IAudioProcessor::iid, (void**)&procRaw) == Steinberg::kResultOk &&
+          procRaw != nullptr)
+      {
+         v->processor = Steinberg::owned(procRaw);
+      }
+
+      v->arrived.store(true, std::memory_order_release);
+      return h;
+   }
+
+   namespace
+   {
+      bool PluginVST3Configure(PluginHandle* h, std::string& outError)
+      {
+         PluginVST3State* v = h->vst3;
+         if (v == nullptr || !v->component || !v->processor)
+         {
+            outError = "missing VST3 component or processor";
+            return false;
+         }
+
+         if (v->processing)
+         {
+            v->processor->setProcessing(false);
+            v->processing = false;
+         }
+         if (v->active)
+         {
+            v->component->setActive(false);
+            v->active = false;
+         }
+
+         const double rate = h->sampleRate > 0.0 ? h->sampleRate : 48000.0;
+         const int frames = std::min(std::max(h->maxBlockFrames, 1), 4096);
+
+         Steinberg::Vst::SpeakerArrangement inArr = Steinberg::Vst::SpeakerArr::kStereo;
+         Steinberg::Vst::SpeakerArrangement outArr = Steinberg::Vst::SpeakerArr::kStereo;
+
+         const int inBusCount = v->component->getBusCount(Steinberg::Vst::kAudio, Steinberg::Vst::kInput);
+         const int outBusCount = v->component->getBusCount(Steinberg::Vst::kAudio, Steinberg::Vst::kOutput);
+
+         int inChannels = (inBusCount > 0) ? 2 : 0;
+         int outChannels = (outBusCount > 0) ? 2 : 0;
+
+         if (inBusCount > 0 && outBusCount > 0)
+         {
+            inArr = Steinberg::Vst::SpeakerArr::kStereo;
+            outArr = Steinberg::Vst::SpeakerArr::kStereo;
+            if (v->processor->setBusArrangements(&inArr, 1, &outArr, 1) != Steinberg::kResultOk)
+            {
+               inArr = Steinberg::Vst::SpeakerArr::kMono;
+               outArr = Steinberg::Vst::SpeakerArr::kMono;
+               if (v->processor->setBusArrangements(&inArr, 1, &outArr, 1) == Steinberg::kResultOk)
+               {
+                  inChannels = 1;
+                  outChannels = 1;
+               }
+            }
+         }
+         else if (outBusCount > 0)
+         {
+            inChannels = 0;
+            outArr = Steinberg::Vst::SpeakerArr::kStereo;
+            if (v->processor->setBusArrangements(nullptr, 0, &outArr, 1) != Steinberg::kResultOk)
+            {
+               outArr = Steinberg::Vst::SpeakerArr::kMono;
+               v->processor->setBusArrangements(nullptr, 0, &outArr, 1);
+               outChannels = 1;
+            }
+         }
+
+         v->pluginInChannels = inChannels;
+         v->pluginOutChannels = outChannels;
+
+         if (inBusCount > 0)
+            v->component->activateBus(Steinberg::Vst::kAudio, Steinberg::Vst::kInput, 0, true);
+         if (outBusCount > 0)
+            v->component->activateBus(Steinberg::Vst::kAudio, Steinberg::Vst::kOutput, 0, true);
+
+         Steinberg::Vst::ProcessSetup setup = {};
+         setup.processMode = Steinberg::Vst::kRealtime;
+         setup.symbolicSampleSize = Steinberg::Vst::kSample32;
+         setup.maxSamplesPerBlock = frames;
+         setup.sampleRate = rate;
+
+         if (v->processor->setupProcessing(setup) != Steinberg::kResultOk)
+         {
+            outError = "VST3 setupProcessing failed";
+            return false;
+         }
+
+         if (v->component->setActive(true) != Steinberg::kResultOk)
+         {
+            outError = "VST3 setActive failed";
+            return false;
+         }
+         v->active = true;
+
+         h->latencySamples = (int)v->processor->getLatencySamples();
+
+         const Steinberg::tresult procRes = v->processor->setProcessing(true);
+         if (procRes != Steinberg::kResultOk)
+            VST3Trace("setProcessing(true) returned %d - continuing (optional call)", (int)procRes);
+         v->processing = true;
+
+         v->inScratch.assign((size_t)8 * (size_t)frames, 0.0f);
+         v->outScratch.assign((size_t)8 * (size_t)frames, 0.0f);
+         v->zeroScratch.assign((size_t)frames, 0.0f);
+
+         std::memset(&v->processData, 0, sizeof(v->processData));
+         v->processData.processMode = Steinberg::Vst::kRealtime;
+         v->processData.symbolicSampleSize = Steinberg::Vst::kSample32;
+
+         if (inChannels > 0)
+         {
+            v->processData.numInputs = 1;
+            v->processData.inputs = v->inputBusBuffers;
+            v->inputBusBuffers[0].numChannels = inChannels;
+            v->inputBusBuffers[0].silenceFlags = 0;
+            v->inputBusBuffers[0].channelBuffers32 = v->inChannelPtrs;
+         }
+         else
+         {
+            v->processData.numInputs = 0;
+            v->processData.inputs = nullptr;
+         }
+
+         v->processData.numOutputs = 1;
+         v->processData.outputs = v->outputBusBuffers;
+         v->outputBusBuffers[0].numChannels = outChannels;
+         v->outputBusBuffers[0].silenceFlags = 0;
+         v->outputBusBuffers[0].channelBuffers32 = v->outChannelPtrs;
+
+         v->processData.inputEvents = &v->inputEvents;
+         v->processData.outputEvents = &v->outputEvents;
+         v->processData.inputParameterChanges = &v->inputParamChanges;
+         v->processData.outputParameterChanges = &v->outputParamChanges;
+
+         std::memset(&v->processContext, 0, sizeof(v->processContext));
+         v->processContext.sampleRate = rate;
+         v->processContext.projectTimeSamples = 0;
+         v->processContext.projectTimeMusic = 0.0;
+         v->processContext.tempo = 120.0;
+         v->processContext.timeSigNumerator = 4;
+         v->processContext.timeSigDenominator = 4;
+         v->processContext.state = Steinberg::Vst::ProcessContext::kPlaying |
+                                   Steinberg::Vst::ProcessContext::kProjectTimeMusicValid |
+                                   Steinberg::Vst::ProcessContext::kTempoValid |
+                                   Steinberg::Vst::ProcessContext::kTimeSigValid;
+         v->processData.processContext = &v->processContext;
+
+         return true;
+      }
+   }
+
+   PluginLoadState PluginVST3Poll(PluginHandle* h, std::string& outError)
+   {
+      if (h == nullptr || h->vst3 == nullptr)
+      {
+         outError = "null VST3 plugin handle";
+         return PluginLoadState::Failed;
+      }
+      PluginVST3State* v = h->vst3;
+      if (h->state != PluginLoadState::Pending)
+      {
+         outError = h->loadError;
+         return h->state;
+      }
+      if (!v->arrived.load(std::memory_order_acquire))
+         return PluginLoadState::Pending;
+
+      std::string arrivedErr;
+      {
+         std::lock_guard<std::mutex> lock(v->arrivalMutex);
+         arrivedErr = v->arrivedError;
+      }
+      if (!arrivedErr.empty() || !v->component || !v->processor)
+      {
+         h->state = PluginLoadState::Failed;
+         h->loadError = !arrivedErr.empty() ? arrivedErr : "VST3 failed to instantiate";
+         outError = h->loadError;
+         return h->state;
+      }
+
+      Steinberg::Vst::IHostApplication* hostApp = SharedHostApplication();
+      if (v->component->initialize(hostApp) != Steinberg::kResultOk)
+      {
+         h->state = PluginLoadState::Failed;
+         h->loadError = "VST3 component initialize failed";
+         outError = h->loadError;
+         return h->state;
+      }
+
+      if (v->controller)
+      {
+         v->controller->initialize(hostApp);
+         v->componentHandler = new HostComponentHandler(h);
+         v->controller->setComponentHandler(v->componentHandler);
+
+         Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> compCP;
+         Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> ctrlCP;
+         if (v->component->queryInterface(Steinberg::Vst::IConnectionPoint::iid, (void**)&compCP) == Steinberg::kResultOk &&
+             v->controller->queryInterface(Steinberg::Vst::IConnectionPoint::iid, (void**)&ctrlCP) == Steinberg::kResultOk)
+         {
+            if (compCP && ctrlCP && compCP != ctrlCP)
+            {
+               v->compToCtrlProxy = Steinberg::owned(new HostConnectionProxy(compCP));
+               v->ctrlToCompProxy = Steinberg::owned(new HostConnectionProxy(ctrlCP));
+               v->compToCtrlProxy->connect(ctrlCP);
+               v->ctrlToCompProxy->connect(compCP);
+            }
+         }
+
+         MemoryStream stateStream;
+         if (v->component->getState(&stateStream) == Steinberg::kResultOk)
+         {
+            stateStream.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
+            v->controller->setComponentState(&stateStream);
+         }
+      }
+
+      if (!PluginVST3Configure(h, outError))
+      {
+         h->state = PluginLoadState::Failed;
+         h->loadError = outError;
+         return h->state;
+      }
+
+      h->state = PluginLoadState::Ready;
+      outError.clear();
+      return h->state;
+   }
+
+   bool PluginVST3Prepare(PluginHandle* h, double sampleRate, int maxBlockFrames, std::string& outError)
+   {
+      if (h == nullptr || h->vst3 == nullptr || h->state != PluginLoadState::Ready)
+      {
+         outError = "plugin not ready";
+         return false;
+      }
+      const int frames = maxBlockFrames > 0 ? maxBlockFrames : h->maxBlockFrames;
+      if (sampleRate <= 0.0)
+         return true;
+      if (std::abs(sampleRate - h->sampleRate) < 1e-6 && frames == h->maxBlockFrames && h->vst3->active)
+         return true;
+
+      h->sampleRate = sampleRate;
+      h->maxBlockFrames = frames;
+      h->vst3->sampleRate = sampleRate;
+      h->vst3->maxBlockFrames = frames;
+
+      if (!PluginVST3Configure(h, outError))
+      {
+         h->state = PluginLoadState::Failed;
+         h->loadError = outError;
+         return false;
+      }
+      return true;
+   }
+
+   void PluginVST3Destroy(PluginHandle* h)
+   {
+      if (h == nullptr || h->vst3 == nullptr)
+         return;
+
+      PluginVST3State* v = h->vst3;
+
+      // No editor window teardown here (editor hosting isn't ported this
+      // phase - see PluginVST3OpenEditor below), so v->plugView is always
+      // null in practice; guarded anyway in case that changes.
+      if (v->plugView)
+      {
+         v->plugView = nullptr;
+      }
+
+      if (v->compToCtrlProxy)
+      {
+         v->compToCtrlProxy->DisconnectFromSource();
+         v->compToCtrlProxy = nullptr;
+      }
+      if (v->ctrlToCompProxy)
+      {
+         v->ctrlToCompProxy->DisconnectFromSource();
+         v->ctrlToCompProxy = nullptr;
+      }
+
+      if (v->componentHandler)
+      {
+         v->componentHandler->detach();
+         v->componentHandler = nullptr;
+      }
+
+      // Wait out any in-flight render.
+      for (int spins = 0; spins < 100000 && v->inRender.load(std::memory_order_acquire); spins++)
+      {
+      }
+
+      if (v->processor && v->processing)
+      {
+         v->processor->setProcessing(false);
+         v->processing = false;
+      }
+      if (v->component && v->active)
+      {
+         v->component->setActive(false);
+         v->active = false;
+      }
+
+      if (v->controller)
+      {
+         v->controller->setComponentHandler(nullptr);
+         v->controller->terminate();
+         v->controller = nullptr;
+      }
+      if (v->component)
+      {
+         v->component->terminate();
+         v->component = nullptr;
+      }
+      v->processor = nullptr;
+      v->factory = nullptr;
+
+      if (v->module != nullptr)
+      {
+         UnloadVST3Module(v->module);
+         v->module = nullptr;
+      }
+
+      delete v;
+      h->vst3 = nullptr;
+      delete h;
+   }
+
+   void PluginVST3Render(PluginHandle* h, const float* const* in, int inChannels,
+                         float* const* out, int outChannels, int numFrames)
+   {
+      if (h == nullptr || h->vst3 == nullptr || out == nullptr || numFrames <= 0)
+         return;
+
+      PluginVST3State* v = h->vst3;
+      if (!v->processor || !v->processing)
+         return;
+
+      v->inRender.store(true, std::memory_order_release);
+
+      const int pluginIn = v->pluginInChannels;
+      const int pluginOut = v->pluginOutChannels;
+      const int frames = numFrames > v->maxBlockFrames ? v->maxBlockFrames : numFrames;
+
+      v->processData.numSamples = frames;
+      v->processContext.projectTimeSamples = v->sampleTime;
+      const double sr = h->sampleRate > 0.0 ? h->sampleRate : 48000.0;
+      v->processContext.projectTimeMusic = (double)v->sampleTime / sr * (120.0 / 60.0);
+      v->sampleTime += frames;
+
+      if (pluginIn > 0)
+      {
+         for (int ch = 0; ch < pluginIn; ch++)
+         {
+            const float* src = (in != nullptr && inChannels > 0)
+                                  ? in[ch < inChannels ? ch : inChannels - 1]
+                                  : nullptr;
+            v->inChannelPtrs[ch] = const_cast<float*>(src != nullptr ? src : v->zeroScratch.data());
+         }
+      }
+
+      const bool direct = (pluginOut == outChannels);
+      float* outScratchBase = v->outScratch.data();
+      for (int ch = 0; ch < pluginOut; ch++)
+      {
+         v->outChannelPtrs[ch] = direct ? out[ch] : (outScratchBase + (size_t)ch * (size_t)v->maxBlockFrames);
+      }
+
+      const Steinberg::tresult res = v->processor->process(v->processData);
+
+      if (res != Steinberg::kResultOk)
+      {
+         for (int ch = 0; ch < outChannels; ch++)
+            if (out[ch] != nullptr)
+               std::memset(out[ch], 0, (size_t)frames * sizeof(float));
+         v->inputEvents.clear();
+         v->inputParamChanges.clear();
+         v->inRender.store(false, std::memory_order_release);
+         return;
+      }
+
+      if (!direct)
+      {
+         for (int ch = 0; ch < outChannels; ch++)
+         {
+            if (out[ch] == nullptr)
+               continue;
+            const int srcCh = ch < pluginOut ? ch : pluginOut - 1;
+            std::memcpy(out[ch], outScratchBase + (size_t)srcCh * (size_t)v->maxBlockFrames,
+                        (size_t)frames * sizeof(float));
+         }
+      }
+
+      for (int ch = pluginOut; ch < outChannels; ch++)
+         if (out[ch] != nullptr && !direct)
+            std::memset(out[ch], 0, (size_t)frames * sizeof(float));
+
+      v->inputEvents.clear();
+      v->inputParamChanges.clear();
+
+      v->inRender.store(false, std::memory_order_release);
+   }
+
+   void PluginVST3ScheduleMIDIEvent(PluginHandle* h, int frameOffset, const unsigned char* bytes, int byteCount)
+   {
+      if (h == nullptr || h->vst3 == nullptr || bytes == nullptr || byteCount <= 0)
+         return;
+
+      PluginVST3State* v = h->vst3;
+      const unsigned char status = bytes[0] & 0xF0;
+      const unsigned char channel = bytes[0] & 0x0F;
+      const unsigned char note = (byteCount > 1) ? (bytes[1] & 0x7F) : 0;
+      const unsigned char vel = (byteCount > 2) ? (bytes[2] & 0x7F) : 0;
+
+      if (status == 0x90 && vel > 0)
+      {
+         Steinberg::Vst::Event e = {};
+         e.type = Steinberg::Vst::Event::kNoteOnEvent;
+         e.sampleOffset = frameOffset;
+         e.noteOn.channel = channel;
+         e.noteOn.pitch = (Steinberg::int16)note;
+         e.noteOn.velocity = (float)vel / 127.0f;
+         e.noteOn.length = 0;
+         e.noteOn.tuning = 0.0f;
+         e.noteOn.noteId = -1;
+         v->inputEvents.addEvent(e);
+      }
+      else if (status == 0x80 || (status == 0x90 && vel == 0))
+      {
+         Steinberg::Vst::Event e = {};
+         e.type = Steinberg::Vst::Event::kNoteOffEvent;
+         e.sampleOffset = frameOffset;
+         e.noteOff.channel = channel;
+         e.noteOff.pitch = (Steinberg::int16)note;
+         e.noteOff.velocity = (float)vel / 127.0f;
+         e.noteOff.tuning = 0.0f;
+         e.noteOff.noteId = -1;
+         v->inputEvents.addEvent(e);
+      }
+   }
+
+   int PluginVST3ParameterCount(PluginHandle* h)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller)
+         return 0;
+      return (int)h->vst3->controller->getParameterCount();
+   }
+
+   namespace
+   {
+      void FillVST3ParamInfo(const Steinberg::Vst::ParameterInfo& p, PluginParamInfo& out)
+      {
+         out.address = (unsigned long long)p.id;
+         out.displayName = UTF16ToUTF8(p.title);
+         if (out.displayName.empty())
+            out.displayName = UTF16ToUTF8(p.shortTitle);
+         out.minValue = 0.0f;
+         out.maxValue = 1.0f;
+         out.defaultValue = (float)p.defaultNormalizedValue;
+         out.unit = UTF16ToUTF8(p.units);
+      }
+   }
+
+   bool PluginVST3ParameterInfo(PluginHandle* h, int index, PluginParamInfo& out)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller)
+         return false;
+      Steinberg::Vst::ParameterInfo info = {};
+      if (h->vst3->controller->getParameterInfo(index, info) != Steinberg::kResultOk)
+         return false;
+      FillVST3ParamInfo(info, out);
+      return true;
+   }
+
+   bool PluginVST3ParameterInfoByAddress(PluginHandle* h, unsigned long long address, PluginParamInfo& out)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller)
+         return false;
+      const int count = (int)h->vst3->controller->getParameterCount();
+      for (int i = 0; i < count; i++)
+      {
+         Steinberg::Vst::ParameterInfo info = {};
+         if (h->vst3->controller->getParameterInfo(i, info) == Steinberg::kResultOk)
+         {
+            if ((unsigned long long)info.id == address)
+            {
+               FillVST3ParamInfo(info, out);
+               return true;
+            }
+         }
+      }
+      return false;
+   }
+
+   void PluginVST3SetParameter(PluginHandle* h, unsigned long long address, float value)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller)
+         return;
+
+      const Steinberg::Vst::ParamID pid = (Steinberg::Vst::ParamID)address;
+      const Steinberg::Vst::ParamValue normVal = (Steinberg::Vst::ParamValue)std::clamp(value, 0.0f, 1.0f);
+      h->vst3->controller->setParamNormalized(pid, normVal);
+
+      Steinberg::int32 queueIdx = 0;
+      Steinberg::Vst::IParamValueQueue* queue = h->vst3->inputParamChanges.addParameterData(pid, queueIdx);
+      if (queue != nullptr)
+      {
+         Steinberg::int32 ptIdx = 0;
+         queue->addPoint(0, normVal, ptIdx);
+      }
+   }
+
+   bool PluginVST3GetParameter(PluginHandle* h, unsigned long long address, float& outValue)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->controller)
+         return false;
+      outValue = (float)h->vst3->controller->getParamNormalized((Steinberg::Vst::ParamID)address);
+      return true;
+   }
+
+   void PluginVST3BeginLearn(PluginHandle* h)
+   {
+      if (h == nullptr || h->vst3 == nullptr)
+         return;
+      h->vst3->learnedValid.store(false, std::memory_order_relaxed);
+      h->vst3->learning.store(true, std::memory_order_release);
+   }
+
+   void PluginVST3EndLearn(PluginHandle* h)
+   {
+      if (h == nullptr || h->vst3 == nullptr)
+         return;
+      h->vst3->learning.store(false, std::memory_order_release);
+      h->vst3->learnedValid.store(false, std::memory_order_relaxed);
+   }
+
+   bool PluginVST3PollLearned(PluginHandle* h, unsigned long long& outAddress)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->learnedValid.load(std::memory_order_acquire))
+         return false;
+      outAddress = h->vst3->learnedAddress.load(std::memory_order_relaxed);
+      h->vst3->learnedValid.store(false, std::memory_order_relaxed);
+      return true;
+   }
+
+   // ------------------------------------------------------------------------
+   // Crash guard - Windows SEH equivalent of PluginVST3.mm's sigsetjmp guard.
+   // Same discipline: narrow, synchronous, main-thread-only calls with no
+   // in-flight audio riding on them. Deliberately not used around process().
+   // This phase only has state save/restore to guard - there's no editor to
+   // open yet (see PluginVST3OpenEditor below).
+   //
+   // MSVC forbids C++ objects requiring unwinding in a function that also
+   // uses __except (without /EHa) - this function has none: `fn` is a
+   // reference parameter, `what`/`h` are raw pointers, nothing local needs a
+   // destructor run across the guarded region.
+   // ------------------------------------------------------------------------
+   namespace
+   {
+      bool RunPluginCallGuarded(const char* what, PluginHandle* h, const std::function<void()>& fn)
+      {
+         __try
+         {
+            fn();
+         }
+         __except (EXCEPTION_EXECUTE_HANDLER)
+         {
+            const char* name = (h != nullptr) ? h->desc.name.c_str() : "?";
+            std::fprintf(stderr, "[VST3] plugin '%s' crashed inside %s - call aborted\n", name, what);
+            return false;
+         }
+         return true;
+      }
+   }
+
+   // ------------------------------------------------------------------------
+   // Editor window - not ported this phase. HWND creation/embedding via
+   // kPlatformTypeHWND is real, substantial work (see the plan) and becomes
+   // its own follow-up session.
+   // ------------------------------------------------------------------------
+
+   bool PluginVST3OpenEditor(PluginHandle* h, std::string& outError)
+   {
+      (void)h;
+      outError = "VST3 editor hosting is not yet available on Windows";
+      return false;
+   }
+
+   void PluginVST3CloseEditor(PluginHandle* h)
+   {
+      (void)h;
+   }
+
+   bool PluginVST3EditorIsOpen(PluginHandle* h)
+   {
+      (void)h;
+      return false;
+   }
+
+   // ------------------------------------------------------------------------
+   // State Save & Restore
+   // ------------------------------------------------------------------------
+
+   bool PluginVST3SaveState(PluginHandle* h, std::string& outBase64)
+   {
+      outBase64.clear();
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->component)
+         return false;
+      if (h->vst3->stateCallsUnstable.load(std::memory_order_relaxed))
+         return false;
+
+      MemoryStream compStream;
+      Steinberg::tresult compResult = Steinberg::kResultFalse;
+      if (!RunPluginCallGuarded("getState (component)", h, [&]
+             { compResult = h->vst3->component->getState(&compStream); }))
+      {
+         h->vst3->stateCallsUnstable.store(true, std::memory_order_relaxed);
+         return false;
+      }
+      if (compResult != Steinberg::kResultOk)
+         return false;
+
+      MemoryStream ctrlStream;
+      if (h->vst3->controller)
+      {
+         if (!RunPluginCallGuarded("getState (controller)", h, [&]
+                { h->vst3->controller->getState(&ctrlStream); }))
+         {
+            h->vst3->stateCallsUnstable.store(true, std::memory_order_relaxed);
+            return false;
+         }
+      }
+
+      const uint64_t compSize = (uint64_t)compStream.getSize();
+      const uint64_t ctrlSize = (uint64_t)ctrlStream.getSize();
+
+      std::vector<uint8_t> payload;
+      payload.resize(sizeof(uint64_t) + compSize + sizeof(uint64_t) + ctrlSize);
+
+      uint8_t* ptr = payload.data();
+      std::memcpy(ptr, &compSize, sizeof(uint64_t));
+      ptr += sizeof(uint64_t);
+      if (compSize > 0)
+      {
+         std::memcpy(ptr, compStream.getBuffer().data(), (size_t)compSize);
+         ptr += compSize;
+      }
+      std::memcpy(ptr, &ctrlSize, sizeof(uint64_t));
+      ptr += sizeof(uint64_t);
+      if (ctrlSize > 0)
+      {
+         std::memcpy(ptr, ctrlStream.getBuffer().data(), (size_t)ctrlSize);
+      }
+
+      outBase64 = Base64Encode(payload);
+      return !outBase64.empty();
+   }
+
+   bool PluginVST3RestoreState(PluginHandle* h, const std::string& base64)
+   {
+      if (h == nullptr || h->vst3 == nullptr || !h->vst3->component || base64.empty())
+         return false;
+      if (h->vst3->stateCallsUnstable.load(std::memory_order_relaxed))
+         return false;
+
+      std::vector<uint8_t> payload;
+      if (!Base64Decode(base64, payload))
+         return false;
+
+      if (payload.size() < sizeof(uint64_t) * 2)
+         return false;
+
+      const uint8_t* ptr = payload.data();
+      const uint8_t* end = payload.data() + payload.size();
+
+      uint64_t compSize = 0;
+      std::memcpy(&compSize, ptr, sizeof(uint64_t));
+      ptr += sizeof(uint64_t);
+
+      if (ptr + compSize > end)
+         return false;
+      if (compSize > 0)
+      {
+         bool ok = RunPluginCallGuarded("setState (component)", h, [&]
+         {
+            MemoryStream compStream(ptr, (size_t)compSize);
+            h->vst3->component->setState(&compStream);
+            if (h->vst3->controller)
+            {
+               compStream.seek(0, Steinberg::IBStream::kIBSeekSet, nullptr);
+               h->vst3->controller->setComponentState(&compStream);
+            }
+         });
+         if (!ok)
+         {
+            h->vst3->stateCallsUnstable.store(true, std::memory_order_relaxed);
+            return false;
+         }
+         ptr += compSize;
+      }
+
+      if (ptr + sizeof(uint64_t) <= end)
+      {
+         uint64_t ctrlSize = 0;
+         std::memcpy(&ctrlSize, ptr, sizeof(uint64_t));
+         ptr += sizeof(uint64_t);
+         if (ctrlSize > 0 && ptr + ctrlSize <= end && h->vst3->controller)
+         {
+            if (!RunPluginCallGuarded("setState (controller)", h, [&]
+                   {
+                      MemoryStream ctrlStream(ptr, (size_t)ctrlSize);
+                      h->vst3->controller->setState(&ctrlStream);
+                   }))
+            {
+               h->vst3->stateCallsUnstable.store(true, std::memory_order_relaxed);
+               return false;
+            }
+         }
+      }
+
+      return true;
+   }
+}
+
+#endif // INFINITE_ENABLE_VST3

--- a/src/platform/win/PluginVST3Win.cpp
+++ b/src/platform/win/PluginVST3Win.cpp
@@ -258,6 +258,12 @@ namespace
 {
    namespace fsProbe = std::filesystem;
 
+   // Forward declarations: DescribeVST3Bundle below (in the Platform block
+   // right after this one) needs these before their full definitions, which
+   // live further down in the module-loading section of this file.
+   HMODULE LoadVST3Module(const std::string& bundlePath, Steinberg::IPluginFactory** outFactory);
+   void UnloadVST3Module(HMODULE module);
+
    // ------------------------------------------------------------------------
    // User-added VST3 search folders - mirrors PluginVST3.mm's
    // gExtraVST3SearchFolders exactly (same call site: PluginScanner::Folders()
@@ -2147,7 +2153,11 @@ namespace
          wc.style = CS_HREDRAW | CS_VREDRAW;
          wc.lpfnWndProc = PluginEditorWndProc;
          wc.hInstance = GetModuleHandleW(nullptr);
-         wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+         // IDC_ARROW resolves to an ANSI LPSTR unless the UNICODE macro is
+         // defined for the translation unit (it isn't, here or on the main
+         // Infinite target) - spell out the wide resource ID explicitly
+         // instead of relying on that macro.
+         wc.hCursor = LoadCursorW(nullptr, MAKEINTRESOURCEW(32512));
          wc.lpszClassName = kEditorWindowClassName;
          return RegisterClassExW(&wc);
       }();

--- a/src/scanner_main_win.cpp
+++ b/src/scanner_main_win.cpp
@@ -1,0 +1,53 @@
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <fcntl.h>
+#include <io.h>
+
+#include "Platform.h"
+#include "PluginVST3.h"
+
+int main(int argc, char** argv)
+{
+   // stdout defaults to text mode, which translates '\n' to '\r\n' and
+   // corrupts the tab-separated wire format the parent parses by comparing
+   // fields to exact strings like "1" (see PluginVST3Win.cpp's
+   // ParseProbeOutput, which strips a trailing '\r' defensively as the other
+   // half of this fix).
+   _setmode(_fileno(stdout), _O_BINARY);
+
+   if (argc < 2)
+      return 1;
+
+   auto sanitize = [](std::string s)
+   {
+      for (char& c : s)
+         if (c == '\t' || c == '\n' || c == '\r')
+            c = ' ';
+      return s;
+   };
+
+   int startIdx = 1;
+   if (std::strcmp(argv[1], "--batch") == 0)
+      startIdx = 2;
+
+   for (int i = startIdx; i < argc; i++)
+   {
+      const char* bundlePath = argv[i];
+      if (bundlePath == nullptr || bundlePath[0] == '\0')
+         continue;
+
+      std::vector<Platform::PluginDesc> descs;
+      Platform::DescribeVST3Bundle(bundlePath, descs);
+      for (const Platform::PluginDesc& d : descs)
+      {
+         std::printf("%s\t%s\t%s\t%s\t%s\t%d\n", sanitize(d.format).c_str(), sanitize(d.name).c_str(),
+                     sanitize(d.manufacturer).c_str(), sanitize(d.identifier).c_str(), sanitize(d.path).c_str(),
+                     d.acceptsNotes ? 1 : 0);
+      }
+      std::fflush(stdout);
+   }
+   return 0;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -430,17 +430,13 @@
           <div class="section-label">First-Time Setup</div>
           <h2 class="section-heading">Opening Infinite on Windows in 3 Steps</h2>
           <p class="setup-intro">
-            The Windows build is a portable folder &mdash; there is no installer, and nothing is
-            written to your registry. It is unsigned, so Windows shows a one-time warning on the
-            first launch. Here is how to get past it:
-          </p>
-          <p class="setup-intro">
-            The download button gives you the <strong>Intel / AMD (x64)</strong> build, which is
-            what almost every PC needs. On an ARM machine &mdash; a Snapdragon X laptop, or a Mac
-            running Windows in Parallels &mdash; take the
+            The Windows build is a portable folder &mdash; no installer, nothing written to your
+            registry. It's unsigned, so Windows shows a one-time warning on first launch. Most PCs
+            need the <strong>Intel / AMD (x64)</strong> build from the download button; ARM
+            machines (Snapdragon X, or Windows in Parallels on a Mac) need the
             <a href="https://github.com/n1m21n/Infinite/releases/latest/download/Infinite-windows-ARM64.zip">ARM64 build</a>
-            instead. Windows tells you which you have under
-            <strong>Settings &rarr; System &rarr; About &rarr; System type</strong>.
+            instead &mdash; check <strong>Settings &rarr; System &rarr; About &rarr; System type</strong>
+            if unsure. Here's how to open it:
           </p>
 
           <div class="steps-grid">
@@ -462,16 +458,6 @@
               <p class="step-desc">Patches save as <code>.infinite</code> files. Windows will not know what they are until you tell it once: right-click a patch, choose <strong>Open with &rarr; Choose another app</strong>, pick <code>Infinite.exe</code> and tick <strong>Always</strong>. Dragging a patch onto the canvas works right away, with no setup.</p>
             </div>
           </div>
-
-          <p class="setup-intro setup-note">
-            <strong>Windows is new here.</strong> The port landed with generous help from
-            <a href="https://github.com/ThatManMatthias" target="_blank" rel="noopener">ThatManMatthias</a>,
-            and it has had far less real-world use than the Mac build. Two things are known to be
-            off: MIDI clock sync does not drive the transport, and the Text 3D node sizes its
-            letters incorrectly. Everything else is expected to work &mdash; if it does not, please
-            <a href="https://github.com/n1m21n/Infinite/issues" target="_blank" rel="noopener">open an issue</a>
-            and say which build you took.
-          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Hosts VST3 plugins on Windows: loads the SDK's IComponent/IEditController/IAudioProcessor directly, with a real HWND-embedded editor window.
- Out-of-process scanning (`infinite-vst3-scanner.exe`) so a crashing/hanging plugin only kills a disposable child process, not the app.
- Sentinel + blocklist crash safety under `%APPDATA%\Infinite`, mirroring the macOS backend.
- `INFINITE_ENABLE_VST3` defaults ON (GPLv3 licensing consequence accepted, see LICENSE).

## Status
- CI is green on all three jobs: macOS (arm64), Windows x64 (build + headless self-tests + static-CRT check), Windows ARM64 (compile-only).
- **Not yet verified on real Windows hardware.** CI proves compile/link only — no local MSVC exists in this environment. Currently being tested in a Parallels Windows VM; the rescan button is reportedly not working there (cause not yet diagnosed — possibly Parallels-specific).
- Tier 3 SEH guarding (realtime `process()` calls / plugin instantiation) is explicitly out of scope — not achievable via `__try`/`__except`, flagged in `docs/windows-vst3-status.md`.

See `docs/windows-vst3-status.md` for the full gap-by-gap writeup and what CI does/doesn't prove.

## Test plan
- [x] CI: macOS build + headless self-tests
- [x] CI: Windows x64 build + headless self-tests + static CRT check
- [x] CI: Windows ARM64 build (compile-only)
- [ ] Manual: load a real VST3 plugin on Windows, confirm editor window opens
- [ ] Manual: fix/verify the rescan button issue seen in Parallels testing
- [ ] Manual: confirm a crashing plugin gets caught by the scanner/blocklist instead of taking down the app