### PR TITLE
Fix black output windows on shared OpenGL contexts

### DIFF
--- a/src/core/GLUtil.cpp
+++ b/src/core/GLUtil.cpp
@@ -1,8 +1,11 @@
 #include "GLUtil.h"
 
 #include "gl3.h"
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
 #include <cstdio>
 #include <cstdlib>
+#include <unordered_map>
 
 namespace GLUtil
 {
@@ -16,13 +19,15 @@ namespace GLUtil
       "   gl_Position = vec4(aPos, 0.0, 1.0);\n"
       "}\n";
 
-   static unsigned int sQuadVao = 0;
+   static std::unordered_map<GLFWwindow*, unsigned int> sQuadVaos;
    static unsigned int sQuadVbo = 0;
 
-   static void EnsureQuad()
+   static unsigned int EnsureQuad()
    {
-      if (sQuadVao != 0)
-         return;
+      GLFWwindow* context = glfwGetCurrentContext();
+      auto found = sQuadVaos.find(context);
+      if (found != sQuadVaos.end())
+         return found->second;
 
       // clip-space pos.xy, uv.xy - a single GL_TRIANGLE_STRIP covering the viewport
       float verts[] = {
@@ -32,24 +37,41 @@ namespace GLUtil
          1.0f, 1.0f, 1.0f, 1.0f
       };
 
-      glGenVertexArrays(1, &sQuadVao);
-      glGenBuffers(1, &sQuadVbo);
-      glBindVertexArray(sQuadVao);
+      unsigned int vao = 0;
+      glGenVertexArrays(1, &vao);
+      if (sQuadVbo == 0)
+      {
+         glGenBuffers(1, &sQuadVbo);
+         glBindBuffer(GL_ARRAY_BUFFER, sQuadVbo);
+         glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
+      }
+      glBindVertexArray(vao);
       glBindBuffer(GL_ARRAY_BUFFER, sQuadVbo);
-      glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
       glEnableVertexAttribArray(0);
       glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
       glEnableVertexAttribArray(1);
       glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
       glBindVertexArray(0);
+      sQuadVaos[context] = vao;
+      return vao;
    }
 
    static void DrawQuad()
    {
-      EnsureQuad();
-      glBindVertexArray(sQuadVao);
+      const unsigned int vao = EnsureQuad();
+      glBindVertexArray(vao);
       glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
       glBindVertexArray(0);
+   }
+
+   void ForgetCurrentContextObjects()
+   {
+      GLFWwindow* context = glfwGetCurrentContext();
+      auto found = sQuadVaos.find(context);
+      if (found == sQuadVaos.end())
+         return;
+      glDeleteVertexArrays(1, &found->second);
+      sQuadVaos.erase(found);
    }
 
    bool EnsureFbo(Fbo& fbo, int w, int h, unsigned int internalFormat)

--- a/src/core/GLUtil.h
+++ b/src/core/GLUtil.h
@@ -49,6 +49,11 @@ namespace GLUtil
    void DrawTextureToScreen(unsigned int tex, int windowW, int windowH,
                              int texW = 0, int texH = 0, bool checkerBg = false);
 
+   // VAOs are context-local even when GLFW contexts share textures, programs
+   // and buffers. Auxiliary output windows must release their own fullscreen
+   // quad VAO while their context is still current.
+   void ForgetCurrentContextObjects();
+
    // Reads an existing GPU texture's pixels back to the CPU as RGBA floats,
    // for nodes that need to sample a texture per-vertex rather than per-pixel
    // (e.g. displacing a mesh). `scratchFbo` is a caller-owned, lazily-created

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21194,12 +21194,18 @@ namespace
    {
       if (i >= gProjectorWindows.size())
          return;
-      // Drop this node's solo-render FBO too, if it had one (geometry nodes
-      // only - see gProjectorViewports). Safe to erase immediately: unlike
-      // gRetiredViewports, nothing queues this texture into an ImGui draw
-      // list, it's only ever read by our own immediate GL blit this frame.
-      gProjectorViewports.erase(gProjectorWindows[i].nodeIndex);
-      glfwDestroyWindow(gProjectorWindows[i].window);
+      ProjectorWindow victim = gProjectorWindows[i];
+      GLFWwindow* previous = glfwGetCurrentContext();
+      glfwMakeContextCurrent(victim.window);
+      // Geometry preview FBOs and the fullscreen-quad VAO belong to this
+      // auxiliary context. Release them before the GLFW window destroys it.
+      gProjectorViewports.erase(victim.nodeIndex);
+      GLUtil::ForgetCurrentContextObjects();
+      if (previous != victim.window)
+         glfwMakeContextCurrent(previous);
+      else
+         glfwMakeContextCurrent(nullptr);
+      glfwDestroyWindow(victim.window);
       gProjectorWindows.erase(gProjectorWindows.begin() + (ptrdiff_t)i);
    }
 
@@ -21216,10 +21222,8 @@ namespace
 
    void CloseAllProjectorWindows()
    {
-      for (ProjectorWindow& pw : gProjectorWindows)
-         glfwDestroyWindow(pw.window);
-      gProjectorWindows.clear();
-      gProjectorViewports.clear();
+      while (!gProjectorWindows.empty())
+         CloseProjectorWindow(gProjectorWindows.size() - 1);
    }
 
    // Finds the open projector window (if any) showing this node index.


### PR DESCRIPTION
## Summary

Fixes auxiliary output windows rendering black on Windows while the same node displays correctly in the editor viewport.

## Cause

OpenGL vertex array objects are context-local. The fullscreen quad VAO created in the main GLFW context was being reused by auxiliary output contexts, where it was invalid.

## Changes

- Maintain one fullscreen quad VAO per GLFW context.
- Continue sharing textures, programs and buffers normally.
- Release context-local objects before destroying an output window.
- Preserve fullscreen, second-monitor selection and topmost behavior.

## Tested

- Windows 11
- NVIDIA RTX 4060
- Windowed output
- Second monitor
- F11 fullscreen
- Escape from fullscreen
- Closing and reopening the output window
- Shape and video output